### PR TITLE
Update to 26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **DISCLAIMER: None of the content that can be downloaded from the mod was created by me. Everything (but the mod) was created by the VanillaTweaks team.**
 
 [ ![GitHub release](https://img.shields.io/github/v/release/IotaBread/VTDownloader?color=blue&include_prereleases&label=download&style=flat-square) ](https://github.com/IotaBread/VTDownloader/releases/latest)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/IotaBread/VTDownloader/gradle.yml?branch=1.19&style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/IotaBread/VTDownloader/gradle.yml?Branch=26.1&style=flat-square)
 
 **Requires [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api) to work properly**
 
@@ -23,4 +23,5 @@ Suggestions? [Start a discussion](https://github.com/IotaBread/VTDownloader/disc
 
 ### Planned features
 
-- Datapacks
+- In-game pack version selection
+- Support for datapack downloading

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
-	alias libs.plugins.fabric.loom
-	alias libs.plugins.minotaur
-	alias libs.plugins.cursegradle
+	alias(libs.plugins.fabric.loom)
+	alias(libs.plugins.minotaur)
 	id 'maven-publish'
 }
 
@@ -17,33 +16,14 @@ boolean isBuild = System.getenv('GITHUB_WORKFLOW') == 'build'
 version = !isBuild ? version : "${version}+build.${System.getenv('GITHUB_RUN_NUMBER')}"
 
 repositories {
-	maven {
-		name = 'Quilt'
-		url = 'https://maven.quiltmc.org/repository/release'
-	}
-	maven {
-		name = 'Quilt Snapshots'
-		url = 'https://maven.quiltmc.org/repository/snapshot'
-	}
-
-	// Recursive resources maven
-	maven { url "https://maven.enjarai.nl/releases" }
-	// Required for recursive resources
-	maven { url "https://maven.enjarai.nl/mirrors" }
 }
 
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft libs.minecraft
-	mappings variantOf(libs.quilt.mappings) { classifier("intermediary-v2") }
-	modImplementation libs.fabric.loader
+	implementation libs.fabric.loader
 
-	modImplementation libs.fabric.api
-
-	// With modImplementation it breaks on runtime
-	modCompileOnly(libs.recursive.resources) {
-		exclude group: "com.terraformersmc", module: "modmenu"
-	}
+	implementation libs.fabric.api
 }
 
 processResources {
@@ -62,13 +42,17 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.20.5 upwards uses Java 21.
-	it.options.release = 21
+	// Minecraft 26.1 upwards uses Java 25.
+	it.options.release = 25
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(25)
+	}
+
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.
 	// If you remove this line, sources will not be generated.
@@ -77,7 +61,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.archives_base_name}" }
 	}
 }
 
@@ -86,36 +70,13 @@ modrinth {
 	projectId = '1E2sq1cp'
 	versionNumber = project.version
 	versionName = "VTDownloader ${project.mod_version} for Minecraft ${mcVersion}"
-	uploadFile = remapJar
+	uploadFile = jar
 	changelog = "A changelog can be found at https://github.com/IotaBread/VTDownloader/releases/tag/${project.mod_version}"
 	gameVersions = [mcVersion]
 	loaders = ['fabric', 'quilt']
 }
 
-curseforge {
-	if (project.hasProperty('curse_api_key') || System.getenv('CURSE_API_KEY') != null) {
-		apiKey = project.hasProperty('curse_api_key') ? project.property('curse_api_key') : System.getenv('CURSE_API_KEY')
-	}
-	project {
-		id = '432425'
-		changelog = "A changelog can be found at https://github.com/IotaBread/VTDownloader/releases/tag/${project.mod_version}"
-		releaseType = 'release'
-		addGameVersion mcVersion
-		addGameVersion 'Fabric'
-		addGameVersion 'Quilt'
-		mainArtifact(remapJar) {
-			displayName = "VTDownloader ${project.mod_version} for Minecraft ${mcVersion}"
-		}
-		afterEvaluate {
-			uploadTask.dependsOn('remapJar')
-		}
-	}
-	options {
-		forgeGradleIntegration = false
-	}
-}
-
-publish.finalizedBy tasks.modrinth, tasks.curseforge
+publish.finalizedBy tasks.modrinth
 
 // configure the maven publication
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs = -Xmx1G
 
 # Which version of vanilla tweaks to use
 # TODO: Add ingame selection
-vt_version         = 1.21
+vt_version         = 26.1
 
 # Remember to also update on VTDMod.java
-mod_version        = 2.4.1
+mod_version        = 2.4.2
 maven_group        = dev.iotabread
 archives_base_name = vt-downloader

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,15 @@
 [versions]
-minecraft = "1.21.11"
-quilt_mappings = "1.21.11+build.2"
-fabric_loader = "0.18.4"
+minecraft = "26.1"
+fabric_loader = "0.19.3"
 
-fabric_api = "0.141.3+1.21.11"
-
-# Other mods
-recursive_resources = "2.7.2+1.21.7"
+fabric_api = "0.145.1+26.1"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
-quilt_mappings = { module = "org.quiltmc:quilt-mappings", version.ref = "quilt_mappings" }
-fabric_loader =  { module = "net.fabricmc:fabric-loader", version.ref = "fabric_loader" }
+fabric_loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric_loader" }
 
 fabric_api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric_api" }
 
-recursive_resources = { module = "nl.enjarai:recursive-resources", version.ref = "recursive_resources" }
-
 [plugins]
-fabric_loom = { id = "fabric-loom", version = "1.13.6" }
-minotaur = { id = "com.modrinth.minotaur", version = "2.8.10" }
-cursegradle = { id = "com.matthewprenger.cursegradle", version = "1.4.0" }
+fabric_loom = { id = "net.fabricmc.fabric-loom", version = "1.15.5" }
+minotaur = { id = "com.modrinth.minotaur", version = "2.9.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Thu Jun 04 15:05:32 EDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,10 @@
 pluginManagement {
     repositories {
         maven {
-            name = 'Quilt'
-            url = 'https://maven.quiltmc.org/repository/release'
-        }
-        maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
-        maven {
-            name = 'Cotton'
-            url = 'https://server.bbkr.space/artifactory/libs-release/'
-        }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/VTDMod.java
+++ b/src/main/java/me/bymartrixx/vtd/VTDMod.java
@@ -3,7 +3,7 @@ package me.bymartrixx.vtd;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.mojang.blaze3d.texture.NativeImage;
+import com.mojang.blaze3d.platform.NativeImage;
 import me.bymartrixx.vtd.data.DownloadPackRequestData;
 import me.bymartrixx.vtd.data.DownloadPackResponseData;
 import me.bymartrixx.vtd.data.Pack;
@@ -14,11 +14,10 @@ import me.bymartrixx.vtd.util.Constants;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
-import net.minecraft.resource.ResourceIoSupplier;
-import net.minecraft.resource.pack.PackProfile;
-import net.minecraft.resource.pack.ResourcePack;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.Pair;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.PackResources;
+import net.minecraft.server.packs.resources.IoSupplier;
+import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -76,8 +75,8 @@ public class VTDMod implements ClientModInitializer {
     public static RpCategories rpCategories;
 
     static {
-        String version = "2.4.1";
-        String vtVersion = "1.21";
+        String version = "2.4.2";
+        String vtVersion = "26.1";
 
         Optional<ModContainer> container = FabricLoader.getInstance().getModContainer(MOD_ID);
         if (container.isPresent()) {
@@ -183,7 +182,7 @@ public class VTDMod implements ClientModInitializer {
                                 .header("User-Agent", USER_AGENT)
                                 .timeout(Duration.ofSeconds(4L))
                                 .build();
-                        return new Pair<>(fileName, getClient().send(fileReq, HttpResponse.BodyHandlers.ofInputStream()));
+                        return new Tuple<>(fileName, getClient().send(fileReq, HttpResponse.BodyHandlers.ofInputStream()));
                     } catch (IOException | InterruptedException e) {
                         throw new RuntimeException("Failed to execute pack download request", e);
                     }
@@ -191,13 +190,13 @@ public class VTDMod implements ClientModInitializer {
                 .thenApplyAsync(data -> {
                     progressCallback.accept(0.4F);
 
-                    HttpResponse<InputStream> response = data.getRight();
+                    HttpResponse<InputStream> response = data.getB();
                     int code = response.statusCode();
                     if (code / 100 != 2) {
                         throw new IllegalStateException("Pack download request returned status code " + code);
                     }
 
-                    String fileName = data.getLeft().trim();
+                    String fileName = data.getA().trim();
                     try (InputStream stream = new BufferedInputStream(response.body())) {
                         return Files.copy(stream, downloadPath.resolve(fileName), StandardCopyOption.REPLACE_EXISTING) > 0;
                     } catch (IOException e) {
@@ -270,13 +269,13 @@ public class VTDMod implements ClientModInitializer {
 
     @Contract("_ -> new")
     public static Identifier getIconId(Pack pack) {
-        return Identifier.of(MOD_ID, pack.getId().toLowerCase(Locale.ROOT));
+        return Identifier.fromNamespaceAndPath(MOD_ID, pack.getId().toLowerCase(Locale.ROOT));
     }
 
-    public static CompletableFuture<List<String>> readResourcePackData(PackProfile profile) {
+    public static CompletableFuture<List<String>> readResourcePackData(net.minecraft.server.packs.repository.Pack profile) {
         return CompletableFuture.supplyAsync(() -> {
-            try (ResourcePack resourcePack = profile.createPack()) {
-                ResourceIoSupplier<InputStream> fileStream = resourcePack.openRoot(Constants.SELECTED_PACKS_FILE);
+            try (PackResources resourcePack = profile.open()) {
+                IoSupplier<InputStream> fileStream = resourcePack.getRootResource(Constants.SELECTED_PACKS_FILE);
                 try (InputStream stream = fileStream != null ? fileStream.get() : null){
                     if (stream != null) {
                         return readSelectedPacks(new BufferedReader(new InputStreamReader(stream)));

--- a/src/main/java/me/bymartrixx/vtd/access/AbstractPackAccess.java
+++ b/src/main/java/me/bymartrixx/vtd/access/AbstractPackAccess.java
@@ -1,7 +1,7 @@
 package me.bymartrixx.vtd.access;
 
-import net.minecraft.resource.pack.PackProfile;
+import net.minecraft.server.packs.repository.Pack;
 
 public interface AbstractPackAccess {
-    PackProfile vtdownloader$getProfile();
+    Pack vtdownloader$getProfile();
 }

--- a/src/main/java/me/bymartrixx/vtd/access/PackEntryListWidgetAccess.java
+++ b/src/main/java/me/bymartrixx/vtd/access/PackEntryListWidgetAccess.java
@@ -1,6 +1,6 @@
 package me.bymartrixx.vtd.access;
 
-import net.minecraft.client.gui.screen.pack.PackScreen;
+import net.minecraft.client.gui.screens.packs.PackSelectionScreen;
 
 public interface PackEntryListWidgetAccess {
     boolean vtdownloader$isAvailablePackList();
@@ -9,5 +9,5 @@ public interface PackEntryListWidgetAccess {
 
     boolean vtdownloader$isResourcePackList();
 
-    PackScreen vtdownloader$getScreen();
+    PackSelectionScreen vtdownloader$getScreen();
 }

--- a/src/main/java/me/bymartrixx/vtd/access/TextureManagerAccess.java
+++ b/src/main/java/me/bymartrixx/vtd/access/TextureManagerAccess.java
@@ -1,6 +1,6 @@
 package me.bymartrixx.vtd.access;
 
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 
 public interface TextureManagerAccess {
 	boolean vtdownloader$hasTexture(Identifier id);

--- a/src/main/java/me/bymartrixx/vtd/gui/UnsavedPackWarningScreen.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/UnsavedPackWarningScreen.java
@@ -1,22 +1,22 @@
 package me.bymartrixx.vtd.gui;
 
-import net.minecraft.client.font.MultilineText;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.text.CommonTexts;
-import net.minecraft.text.Text;
-import net.minecraft.unmapped.C_emchntzr;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.TextAlignment;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.MultiLineLabel;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import me.bymartrixx.vtd.util.Util;
 
 public class UnsavedPackWarningScreen extends Screen {
-    private static final Text HEADER = Text.translatable("vtd.unsavedPackWarning.header").formatted(Formatting.BOLD);
-    private static final Text MESSAGE = Text.translatable("vtd.unsavedPackWarning.text");
+    private static final Component HEADER = Component.translatable("vtd.unsavedPackWarning.header").withStyle(ChatFormatting.BOLD);
+    private static final Component MESSAGE = Component.translatable("vtd.unsavedPackWarning.text");
 
     private final VTDownloadScreen parent;
     private final Screen next;
-    private MultilineText message;
+    private MultiLineLabel message;
 
     protected UnsavedPackWarningScreen(VTDownloadScreen parent, Screen next) {
         super(HEADER);
@@ -26,7 +26,7 @@ public class UnsavedPackWarningScreen extends Screen {
 
     @Override
     protected void init() {
-        this.message = Util.createMultilineText(this.textRenderer, MESSAGE, 10, 300);
+        this.message = Util.createMultilineText(this.font, MESSAGE, 10, 300);
 
         int buttonWidth = 150;
         int buttonHeight = 20;
@@ -35,31 +35,31 @@ public class UnsavedPackWarningScreen extends Screen {
         int startX = (this.width - totalWidth) / 2;
         int buttonY = this.height / 2 + 40;
 
-        this.addDrawableSelectableElement(
-                ButtonWidget.builder(CommonTexts.PROCEED, button -> this.client.setScreen(this.next))
-                        .position(startX, buttonY)
+        this.addRenderableWidget(
+                Button.builder(CommonComponents.GUI_PROCEED, button -> this.minecraft.setScreen(this.next))
+                        .pos(startX, buttonY)
                         .size(buttonWidth, buttonHeight)
                         .build());
 
-        this.addDrawableSelectableElement(ButtonWidget.builder(CommonTexts.BACK, button -> this.closeScreen())
-                .position(startX + buttonWidth + spacing, buttonY)
+        this.addRenderableWidget(Button.builder(CommonComponents.GUI_BACK, button -> this.onClose())
+                .pos(startX + buttonWidth + spacing, buttonY)
                 .size(buttonWidth, buttonHeight)
                 .build());
     }
 
     @Override
-    public void closeScreen() {
-        this.client.setScreen(this.parent);
+    public void onClose() {
+        this.minecraft.setScreen(this.parent);
     }
 
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.render(graphics, mouseX, mouseY, delta);
+    public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(graphics, mouseX, mouseY, delta);
 
-        graphics.drawCenteredShadowedText(this.textRenderer, HEADER, this.width / 2, this.height / 2 - 50, 0xFFFFFFFF);
+        graphics.centeredText(this.font, HEADER, this.width / 2, this.height / 2 - 50, 0xFFFFFFFF);
 
         int y = this.height / 2 - 20;
-        C_emchntzr alignment = C_emchntzr.CENTER;
-        this.message.method_75816(alignment, this.width / 2, y, this.textRenderer.fontHeight, graphics.method_75788());
+        TextAlignment alignment = TextAlignment.CENTER;
+        this.message.visitLines(alignment, this.width / 2, y, this.font.lineHeight, graphics.textRenderer());
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/VTDownloadScreen.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/VTDownloadScreen.java
@@ -21,16 +21,14 @@ import me.bymartrixx.vtd.gui.widget.SelectedPacksListWidget;
 import me.bymartrixx.vtd.util.Constants;
 import me.bymartrixx.vtd.util.RenderUtil;
 import me.bymartrixx.vtd.util.Util;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.ParentElement;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.pack.ResourcePackOrganizer;
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.resource.pack.PackProfile;
-import net.minecraft.text.CommonTexts;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.packs.PackSelectionModel;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -48,16 +46,16 @@ public class VTDownloadScreen extends Screen {
     private static final boolean DEBUG_SHARE = false;
     private static final String DEBUG_SHARE_CODE = "abcdef";
 
-    private static final Text TITLE = Text.literal("VTDownloader");
-    private static final Text DOWNLOAD_TEXT = Text.translatable("vtd.download");
-    private static final Text DOWNLOAD_FAILED_TEXT = Text.translatable("vtd.download.failed");
-    private static final Text DOWNLOAD_SUCCESS_TEXT = Text.translatable("vtd.download.success");
-    private static final Text SHARE_TEXT = Text.translatable("vtd.share");
-    private static final Text SHARE_FAILED_TEXT = Text.translatable("vtd.share.failed");
-    private static final Function<Text, Text> SHARE_CODE_TEXT = code -> Text.translatable("vtd.share.code", code);
-    private static final Text READ_PACK_DATA_FAILED_TEXT = Text.translatable("vtd.readPackDataFailed");
-    private static final Text PACK_NAME_FIELD_TEXT = Text.translatable("vtd.resourcePack.nameField");
-    private static final Text PLACEHOLDER_TEXT = Text.literal("Lorem ipsum dolor sit amet");
+    private static final Component TITLE = Component.literal("VTDownloader");
+    private static final Component DOWNLOAD_TEXT = Component.translatable("vtd.download");
+    private static final Component DOWNLOAD_FAILED_TEXT = Component.translatable("vtd.download.failed");
+    private static final Component DOWNLOAD_SUCCESS_TEXT = Component.translatable("vtd.download.success");
+    private static final Component SHARE_TEXT = Component.translatable("vtd.share");
+    private static final Component SHARE_FAILED_TEXT = Component.translatable("vtd.share.failed");
+    private static final Function<Component, Component> SHARE_CODE_TEXT = code -> Component.translatable("vtd.share.code", code);
+    private static final Component READ_PACK_DATA_FAILED_TEXT = Component.translatable("vtd.readPackDataFailed");
+    private static final Component PACK_NAME_FIELD_TEXT = Component.translatable("vtd.resourcePack.nameField");
+    private static final Component PLACEHOLDER_TEXT = Component.literal("Lorem ipsum dolor sit amet");
 
     private static final int WIDGET_HEIGHT = 20;
     private static final int WIDGET_MARGIN = 10;
@@ -89,7 +87,7 @@ public class VTDownloadScreen extends Screen {
     private static final float DEBUG_MESSAGE_TIME = 200.0F;
 
     private final Screen parent;
-    private final Text subtitle;
+    private final Component subtitle;
     private final List<Category> categories;
 
     private Category currentCategory;
@@ -105,14 +103,14 @@ public class VTDownloadScreen extends Screen {
     private PackSelectionListWidget packSelector;
     private SelectedPacksListWidget selectedPacksList;
     private PackNameTextFieldWidget packNameField;
-    private ButtonWidget shareButton;
+    private Button shareButton;
     private MutableMessageButtonWidget downloadButton;
-    private ButtonWidget doneButton;
+    private Button doneButton;
 
     @Nullable
     private String packName;
     @Nullable
-    private ResourcePackOrganizer.Pack pack;
+    private PackSelectionModel.Entry pack;
     @Nullable
     private String defaultPackName;
     private int leftWidth;
@@ -126,7 +124,7 @@ public class VTDownloadScreen extends Screen {
 
     private final PackSelectionHelper selectionHelper = new PackSelectionHelper();
 
-    public VTDownloadScreen(Screen parent, Text subtitle) {
+    public VTDownloadScreen(Screen parent, Component subtitle) {
         super(TITLE);
         this.parent = parent;
         this.subtitle = subtitle;
@@ -140,10 +138,10 @@ public class VTDownloadScreen extends Screen {
         });
     }
 
-    public VTDownloadScreen(Screen parent, Text subtitle, ResourcePackOrganizer.Pack pack) {
+    public VTDownloadScreen(Screen parent, Component subtitle, PackSelectionModel.Entry pack) {
         this(parent, subtitle);
 
-        this.packName = pack.getDisplayName().getString().replaceAll("\\.zip$", "");
+        this.packName = pack.getTitle().getString().replaceAll("\\.zip$", "");
         this.pack = pack;
         this.defaultPackName = this.packName;
     }
@@ -170,7 +168,7 @@ public class VTDownloadScreen extends Screen {
 
     @Nullable
     private String getPackName() {
-        return this.packNameField != null ? this.packNameField.getText() : this.packName;
+        return this.packNameField != null ? this.packNameField.getValue() : this.packName;
     }
 
     private void download() {
@@ -190,8 +188,8 @@ public class VTDownloadScreen extends Screen {
 
         // noinspection ConstantConditions
         CompletableFuture<Boolean> download = VTDMod.executePackDownload(data, f -> this.downloadProgress = f,
-                this.client.getResourcePackDir(),
-                this.packNameField.isBlank() ? null : this.packNameField.getText());
+                this.minecraft.getResourcePackDirectory(),
+                this.packNameField.isBlank() ? null : this.packNameField.getValue());
 
         download.whenCompleteAsync((success, throwable) -> {
             this.updateButtons();
@@ -239,7 +237,7 @@ public class VTDownloadScreen extends Screen {
 
         VTDMod.executeShare(data).whenComplete((code, throwable) -> {
             // Execute on render thread since showSharePopup needs to access render system
-            this.client.execute(() -> {
+            this.minecraft.execute(() -> {
                 if (throwable != null) {
                     VTDMod.LOGGER.error("Failed to get resource pack share code", throwable);
                     this.errorPopup.show(ERROR_MESSAGE_TIME, SHARE_FAILED_TEXT.copy()
@@ -258,15 +256,15 @@ public class VTDownloadScreen extends Screen {
     private void showSharePopup(String code) {
         if (code != null && this.sharePopup != null) {
             String url = VTDMod.BASE_URL + "/share#" + code;
-            Text message = SHARE_CODE_TEXT.apply(Util.urlText(url));
+            Component message = SHARE_CODE_TEXT.apply(Util.urlText(url));
             this.sharePopup.show(SHARE_MESSAGE_TIME, message);
         }
     }
 
     private void readResourcePack() {
         // #AbstractPack and its inheritors are private
-        if (this.pack != null && this.pack.getClass().isNestmateOf(ResourcePackOrganizer.Pack.class)) {
-            PackProfile profile = ((AbstractPackAccess) this.pack).vtdownloader$getProfile();
+        if (this.pack != null && this.pack.getClass().isNestmateOf(PackSelectionModel.Entry.class)) {
+            net.minecraft.server.packs.repository.Pack profile = ((AbstractPackAccess) this.pack).vtdownloader$getProfile();
 
             VTDMod.readResourcePackData(profile).whenCompleteAsync((selection, throwable) -> {
                 if (throwable != null) {
@@ -311,11 +309,11 @@ public class VTDownloadScreen extends Screen {
 
     @SuppressWarnings("ConstantConditions") // client is marked as nullable
     @Override
-    public void closeScreen() {
+    public void onClose() {
         if (this.changed && this.selectionHelper.hasSelection()) {
-            this.client.setScreen(new UnsavedPackWarningScreen(this, this.parent));
+            this.minecraft.setScreen(new UnsavedPackWarningScreen(this, this.parent));
         } else {
-            this.client.setScreen(this.parent);
+            this.minecraft.setScreen(this.parent);
         }
     }
 
@@ -325,79 +323,79 @@ public class VTDownloadScreen extends Screen {
         this.leftWidth = this.width;
 
         // Draw before everything else
-        this.packSelector = this.addDrawable(new PackSelectionListWidget(this.client, this, this.width,
+        this.packSelector = this.addRenderableOnly(new PackSelectionListWidget(this.minecraft, this, this.width,
                 this.height - PACK_SELECTOR_TOP_HEIGHT - PACK_SELECTOR_BOTTOM_HEIGHT,
                 PACK_SELECTOR_TOP_HEIGHT,
                 this.currentCategory, this.selectionHelper));
         this.packSelector.updateCategories(this.categories);
 
-        this.selectedPacksList = this.addDrawable(new SelectedPacksListWidget(this, this.client,
+        this.selectedPacksList = this.addRenderableOnly(new SelectedPacksListWidget(this, this.minecraft,
                 SELECTED_PACKS_WIDTH, this.height - SELECTED_PACKS_TOP_HEIGHT - SELECTED_PACKS_BOTTOM_HEIGHT,
                 this.width - SELECTED_PACKS_WIDTH, SELECTED_PACKS_TOP_HEIGHT,
                 this.selectionHelper));
 
         // Reload button
-        this.addDrawableSelectableElement(new ReloadButtonWidget(WIDGET_MARGIN, WIDGET_MARGIN,
+        this.addRenderableWidget(new ReloadButtonWidget(WIDGET_MARGIN, WIDGET_MARGIN,
                 Constants.RESOURCE_PACK_RELOAD_TEXT, button -> this.reloadCategories()));
 
-        if (DEBUG_BUTTON) this.addDrawableSelectableElement(new DebugButtonWidget(WIDGET_MARGIN * 2 + ReloadButtonWidget.BUTTON_SIZE,
+        if (DEBUG_BUTTON) this.addRenderableWidget(new DebugButtonWidget(WIDGET_MARGIN * 2 + ReloadButtonWidget.BUTTON_SIZE,
                 WIDGET_MARGIN, PLACEHOLDER_TEXT, button -> {
             if (this.debugPopup != null) this.debugPopup.show(DEBUG_MESSAGE_TIME, PLACEHOLDER_TEXT);
         }));
 
-        this.categorySelector = this.addDrawableSelectableElement(new CategorySelectionWidget(this, CATEGORY_SELECTOR_Y));
+        this.categorySelector = this.addRenderableWidget(new CategorySelectionWidget(this, CATEGORY_SELECTOR_Y));
         this.categorySelector.init(this.categories, this.currentCategory);
 
-        ExpandDrawerButtonWidget expandButton = this.addDrawable(new ExpandDrawerButtonWidget(this.width - ExpandDrawerButtonWidget.TAB_WIDTH,
+        ExpandDrawerButtonWidget expandButton = this.addRenderableOnly(new ExpandDrawerButtonWidget(this.width - ExpandDrawerButtonWidget.TAB_WIDTH,
                 SELECTED_PACKS_TOP_HEIGHT + SELECTED_PACKS_BUTTON_Y,
                 SELECTED_PACKS_WIDTH, e -> this.toggleSelectedPacksListExtended()));
 
         // Handle clicks before the pack selector
-        this.sharePopup = this.addSelectableElement(new MessageScreenPopup(this.client, this,
+        this.sharePopup = this.addWidget(new MessageScreenPopup(this.minecraft, this,
                 this.width / 2, this.height / 2,
                 this.width / 2, (int) (this.height / 1.5), SHARE_TEXT));
-        this.errorPopup = this.addSelectableElement(new MessageScreenPopup(this.client, this,
+        this.errorPopup = this.addWidget(new MessageScreenPopup(this.minecraft, this,
                 this.width / 2, this.height / 2,
                 this.width / 2, (int) (this.height / 1.5), Constants.ERROR_TEXT));
-        if (DEBUG_BUTTON) this.debugPopup = this.addSelectableElement(new MessageScreenPopup(this.client, this,
+        if (DEBUG_BUTTON) this.debugPopup = this.addWidget(new MessageScreenPopup(this.minecraft, this,
                 this.width / 2, this.height / 2,
                 this.width / 2, (int) (this.height / 1.5), PLACEHOLDER_TEXT));
 
-        this.addSelectableElement(expandButton);
-        this.addSelectableElement(this.packSelector);
-        this.addSelectableElement(this.selectedPacksList);
+        this.addWidget(expandButton);
+        this.addWidget(this.packSelector);
+        this.addWidget(this.selectedPacksList);
 
-        this.shareButton = this.addDrawableSelectableElement(ButtonWidget.builder(SHARE_TEXT, button -> this.share())
-                .position(this.leftWidth + SELECTED_PACKS_CENTER_X - SHARE_BUTTON_CENTER_X,
+        this.shareButton = this.addRenderableWidget(Button.builder(SHARE_TEXT, button -> this.share())
+                .pos(this.leftWidth + SELECTED_PACKS_CENTER_X - SHARE_BUTTON_CENTER_X,
                         this.height - SELECTED_PACKS_BOTTOM_HEIGHT + WIDGET_MARGIN)
                 .size(SHARE_BUTTON_WIDTH, WIDGET_HEIGHT)
                 .build());
 
         // noinspection ConstantConditions
-        this.packNameField = this.addDrawableSelectableElement(new PackNameTextFieldWidget(this.textRenderer,
+        this.packNameField = this.addRenderableWidget(new PackNameTextFieldWidget(this.font,
                 this.width - DONE_BUTTON_WIDTH - WIDGET_MARGIN * 2 - DOWNLOAD_BUTTON_WIDTH - WIDGET_MARGIN - PACK_NAME_FIELD_WIDTH,
                 this.height - WIDGET_HEIGHT - WIDGET_MARGIN, PACK_NAME_FIELD_WIDTH,
                 WIDGET_HEIGHT, this.getPackName(), PACK_NAME_FIELD_TEXT,
-                this.client.getResourcePackDir(), this.defaultPackName));
-        this.packNameField.setChangedListener(s -> this.updateButtons());
+                this.minecraft.getResourcePackDirectory(), this.defaultPackName));
+        this.packNameField.setResponder(s -> this.updateButtons());
         this.packName = null; // Pack name should only be used once
 
-        this.downloadButton = this.addDrawableSelectableElement(new MutableMessageButtonWidget(
+        this.downloadButton = this.addRenderableWidget(new MutableMessageButtonWidget(
                 this.width - DONE_BUTTON_WIDTH - WIDGET_MARGIN * 2 - DOWNLOAD_BUTTON_WIDTH,
                 this.height - WIDGET_HEIGHT - WIDGET_MARGIN, DOWNLOAD_BUTTON_WIDTH, WIDGET_HEIGHT, DOWNLOAD_TEXT,
                 button -> this.download()));
 
-        this.doneButton = this.addDrawableSelectableElement(ButtonWidget.builder(CommonTexts.DONE, button -> this.closeScreen())
-                .position(this.width - DONE_BUTTON_WIDTH - WIDGET_MARGIN, this.height - WIDGET_HEIGHT - WIDGET_MARGIN)
+        this.doneButton = this.addRenderableWidget(Button.builder(CommonComponents.GUI_DONE, button -> this.onClose())
+                .pos(this.width - DONE_BUTTON_WIDTH - WIDGET_MARGIN, this.height - WIDGET_HEIGHT - WIDGET_MARGIN)
                 .size(DONE_BUTTON_WIDTH, WIDGET_HEIGHT)
                 .build());
 
         // Render over everything else
-        this.progressBar = this.addDrawable(new ProgressBarScreenPopup(this.client, this.width / 2, this.height / 2,
+        this.progressBar = this.addRenderableOnly(new ProgressBarScreenPopup(this.minecraft, this.width / 2, this.height / 2,
                 PROGRESS_BAR_WIDTH, PROGRESS_BAR_HEIGHT, PROGRESS_BAR_COLOR));
-        this.addDrawable(this.sharePopup);
-        this.addDrawable(this.errorPopup);
-        if (this.debugPopup != null) this.addDrawable(this.debugPopup);
+        this.addRenderableOnly(this.sharePopup);
+        this.addRenderableOnly(this.errorPopup);
+        if (this.debugPopup != null) this.addRenderableOnly(this.debugPopup);
 
         this.updateButtons();
         this.readResourcePack();
@@ -440,10 +438,10 @@ public class VTDownloadScreen extends Screen {
     }
 
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.render(graphics, mouseX, mouseY, delta);
-        graphics.drawCenteredShadowedText(this.textRenderer, this.title, this.width / 2, TITLE_Y, 0xFFFFFFFF);
-        graphics.drawCenteredShadowedText(this.textRenderer, this.subtitle, this.width / 2, SUBTITLE_Y, 0xFFFFFFFF);
+    public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(graphics, mouseX, mouseY, delta);
+        graphics.centeredText(this.font, this.title, this.width / 2, TITLE_Y, 0xFFFFFFFF);
+        graphics.centeredText(this.font, this.subtitle, this.width / 2, SUBTITLE_Y, 0xFFFFFFFF);
 
         this.renderDebugInfo(graphics, mouseX, mouseY);
         this.packSelector.renderTooltips(graphics, mouseX, mouseY);
@@ -452,16 +450,16 @@ public class VTDownloadScreen extends Screen {
         this.updateTime(delta);
     }
 
-    private void renderDebugInfo(GuiGraphics graphics, int mouseX, int mouseY) {
+    private void renderDebugInfo(GuiGraphicsExtractor graphics, int mouseX, int mouseY) {
         this.packSelector.renderDebugInfo(graphics, mouseX, mouseY);
         this.categorySelector.renderDebugInfo(graphics);
 
         if (!SHOW_DEBUG_INFO) return;
-        TextRenderer textRenderer = this.client.textRenderer;
+        Font textRenderer = this.minecraft.font;
         List<String> debugInfo = List.of(
                 "Ch = " + this.children().stream().map(e -> e.getClass().getSimpleName())
                         .collect(Collectors.joining(", ")),
-                "H = " + this.hoveredElement(mouseX, mouseY),
+                "H = " + this.getChildAt(mouseX, mouseY),
                 "Sm = " + this.sharePopup.isMouseOver(mouseX, mouseY),
                 "MX/MY = " + mouseX + "/" + mouseY
         );
@@ -469,11 +467,11 @@ public class VTDownloadScreen extends Screen {
         RenderUtil.renderDebugInfo(graphics, textRenderer, 0, this.height, debugInfo);
     }
 
-    private void renderPackNameFieldTooltip(GuiGraphics graphics, int mouseX, int mouseY) {
+    private void renderPackNameFieldTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY) {
         if (this.packNameField.isMouseOver(mouseX, mouseY)) {
-            Text text = this.packNameField.getTooltipText();
+            Component text = this.packNameField.getTooltipText();
             if (text != null) {
-                graphics.deferDrawingTooltip(this.textRenderer, text, mouseX, mouseY);
+                graphics.setTooltipForNextFrame(this.font, text, mouseX, mouseY);
             }
         }
     }
@@ -489,7 +487,7 @@ public class VTDownloadScreen extends Screen {
 
     // for some reason the share popup is never reported as the hovered element
     @Override
-    public Optional<Element> hoveredElement(double mouseX, double mouseY) {
+    public Optional<GuiEventListener> getChildAt(double mouseX, double mouseY) {
         if (this.sharePopup.isMouseOver(mouseX, mouseY)) {
             return Optional.of(this.sharePopup);
         } else if (this.errorPopup.isMouseOver(mouseX, mouseY)) {
@@ -498,6 +496,6 @@ public class VTDownloadScreen extends Screen {
             return Optional.of(this.debugPopup);
         }
 
-        return super.hoveredElement(mouseX, mouseY);
+        return super.getChildAt(mouseX, mouseY);
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/popup/AbstractScreenPopup.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/popup/AbstractScreenPopup.java
@@ -1,17 +1,17 @@
 package me.bymartrixx.vtd.gui.popup;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Drawable;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.util.ArgbHelper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.util.ARGB;
 
-public abstract class AbstractScreenPopup implements Drawable {
+public abstract class AbstractScreenPopup implements Renderable {
     private static final int BACKGROUND_TEXTURE_SIZE = 32;
     private static final float FADE_TIME = 20.0F;
 
-    protected final MinecraftClient client;
+    protected final Minecraft client;
     protected final int centerX;
     protected final int centerY;
     private int width;
@@ -21,7 +21,7 @@ public abstract class AbstractScreenPopup implements Drawable {
     private float shownTime;
     private float fadeTime;
 
-    public AbstractScreenPopup(MinecraftClient client, int centerX, int centerY, int width, int height) {
+    public AbstractScreenPopup(Minecraft client, int centerX, int centerY, int width, int height) {
         this.client = client;
         this.centerX = centerX;
         this.centerY = centerY;
@@ -68,7 +68,7 @@ public abstract class AbstractScreenPopup implements Drawable {
     }
 
     protected final int getFadeAlpha() {
-        return ArgbHelper.getChannelByte(this.getFadeOpacity());
+        return ARGB.as8BitChannel(this.getFadeOpacity());
     }
 
     protected void updateSize(int width, int height) {
@@ -107,7 +107,7 @@ public abstract class AbstractScreenPopup implements Drawable {
     protected void reset() {}
 
     @Override
-    public final void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    public final void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         if (this.show) {
             this.renderBackground(graphics);
             this.renderContent(graphics, mouseX, mouseY, delta);
@@ -115,15 +115,15 @@ public abstract class AbstractScreenPopup implements Drawable {
         }
     }
 
-    protected void renderBackground(GuiGraphics graphics) {
+    protected void renderBackground(GuiGraphicsExtractor graphics) {
         int alpha = this.getFadeAlpha();
-        graphics.fill(this.getLeft() - 1, this.getTop() - 1, this.getRight() + 1, this.getBottom() + 1, alpha << 24, alpha << 24);
+        graphics.fillGradient(this.getLeft() - 1, this.getTop() - 1, this.getRight() + 1, this.getBottom() + 1, alpha << 24, alpha << 24);
 
-        int color = ArgbHelper.pack(alpha, 64, 64, 64);
+        int color = ARGB.color(alpha, 64, 64, 64);
         // drawTexture
-        graphics.method_25291(RenderPipelines.GUI_TEXTURED, Screen.MENU_BACKGROUND,
+        graphics.blit(RenderPipelines.GUI_TEXTURED, Screen.MENU_BACKGROUND,
                 this.getLeft(), this.getTop(), 0.0F, 0.0F, this.width, this.height, BACKGROUND_TEXTURE_SIZE, BACKGROUND_TEXTURE_SIZE, color);
     }
 
-    protected abstract void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta);
+    protected abstract void renderContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta);
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/popup/MessageScreenPopup.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/popup/MessageScreenPopup.java
@@ -1,36 +1,36 @@
 package me.bymartrixx.vtd.gui.popup;
 
 import me.bymartrixx.vtd.util.Util;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.MultilineText;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ActiveTextCollector;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.TextAlignment;
+import net.minecraft.client.gui.components.MultiLineLabel;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.unmapped.C_emchntzr;
-import net.minecraft.unmapped.C_gitqeeaa;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import org.lwjgl.glfw.GLFW;
 
 import java.net.URI;
 
-public class MessageScreenPopup extends AbstractScreenPopup implements Element, Selectable {
+public class MessageScreenPopup extends AbstractScreenPopup implements GuiEventListener, NarratableEntry {
     private static final int TITLE_MARGIN = 4;
     private static final int MESSAGE_MARGIN = 2;
 
     private final Screen screen;
-    private final Text title;
+    private final Component title;
     private final int maxWidth;
     private final int maxHeight;
-    private MultilineText message;
+    private MultiLineLabel message;
 
-    public MessageScreenPopup(MinecraftClient client, Screen screen, int centerX, int centerY, int maxWidth, int maxHeight, Text title) {
+    public MessageScreenPopup(Minecraft client, Screen screen, int centerX, int centerY, int maxWidth, int maxHeight, Component title) {
         super(client, centerX, centerY, maxWidth, maxHeight);
         this.screen = screen;
         this.title = title;
@@ -39,55 +39,55 @@ public class MessageScreenPopup extends AbstractScreenPopup implements Element, 
     }
 
     private int getMaxLines() {
-        int h = this.client.textRenderer.fontHeight;
+        int h = this.client.font.lineHeight;
         return (this.maxHeight - TITLE_MARGIN * 2 - h - MESSAGE_MARGIN) / h;
     }
 
     private int getHeight(int lines) {
-        return this.client.textRenderer.fontHeight * (lines + 1) + TITLE_MARGIN * 2 + MESSAGE_MARGIN;
+        return this.client.font.lineHeight * (lines + 1) + TITLE_MARGIN * 2 + MESSAGE_MARGIN;
     }
 
-    public void show(float time, Text message) {
+    public void show(float time, Component message) {
         int maxLines = this.getMaxLines();
 
-        this.message = Util.createMultilineText(this.client.textRenderer, message, maxLines, this.maxWidth);
+        this.message = Util.createMultilineText(this.client.font, message, maxLines, this.maxWidth);
 
-        int height = this.getHeight(this.message.count());
+        int height = this.getHeight(this.message.getLineCount());
         this.updateSize(this.maxWidth, height);
         this.show(time);
     }
 
-    public void visitLines(C_gitqeeaa textCollector) {
-        C_gitqeeaa.C_cnryfyay parameters = textCollector.method_75760();
-        textCollector.method_75764(parameters.method_75782(this.getFadeOpacity()));
-        textCollector.method_75768(C_emchntzr.CENTER, this.centerX, this.getTop() + TITLE_MARGIN, this.title);
+    public void visitLines(ActiveTextCollector textCollector) {
+        ActiveTextCollector.Parameters parameters = textCollector.defaultParameters();
+        textCollector.defaultParameters(parameters.withOpacity(this.getFadeOpacity()));
+        textCollector.accept(TextAlignment.CENTER, this.centerX, this.getTop() + TITLE_MARGIN, this.title);
 
-        TextRenderer textRenderer = this.client.textRenderer;
-        int lineHeight = textRenderer.fontHeight;
+        Font textRenderer = this.client.font;
+        int lineHeight = textRenderer.lineHeight;
         int y = this.getTop() + TITLE_MARGIN * 2 + lineHeight;
-        this.message.method_75816(C_emchntzr.CENTER, this.centerX, y, lineHeight, textCollector);
+        this.message.visitLines(TextAlignment.CENTER, this.centerX, y, lineHeight, textCollector);
     }
 
     @Override
-    protected void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        this.visitLines(graphics.method_75785(GuiGraphics.C_kbymqsba.TOOLTIP_AND_CURSOR));
+    protected void renderContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        this.visitLines(graphics.textRenderer(GuiGraphicsExtractor.HoveredTextEffects.TOOLTIP_AND_CURSOR));
     }
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
         double mouseX = event.x();
         double mouseY = event.y();
-        if (this.shouldShow() && event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1
+        if (this.shouldShow() && event.button() == GLFW.GLFW_MOUSE_BUTTON_1
                 && mouseX >= this.getLeft() && mouseX < this.getRight()
                 && mouseY >= this.getTop() && mouseY < this.getBottom()) {
-            TextRenderer textRenderer = this.client.textRenderer;
+            Font textRenderer = this.client.font;
 
-            C_gitqeeaa.C_abiemazc styleFinder = new C_gitqeeaa.C_abiemazc(textRenderer, (int) mouseX, (int) mouseY);
+            ActiveTextCollector.ClickableStyleFinder styleFinder = new ActiveTextCollector.ClickableStyleFinder(textRenderer, (int) mouseX, (int) mouseY);
             this.visitLines(styleFinder);
-            Style style = styleFinder.method_75777();
+            Style style = styleFinder.result();
 
             if (style != null && style.getClickEvent() != null
-                    && style.getClickEvent().getAction() == ClickEvent.Action.OPEN_URL) {
+                    && style.getClickEvent().action() == ClickEvent.Action.OPEN_URL) {
                 URI uri = ((ClickEvent.OpenUrl) style.getClickEvent()).uri();
                 Util.openUri(this.client, this.screen, uri);
 
@@ -95,7 +95,7 @@ public class MessageScreenPopup extends AbstractScreenPopup implements Element, 
             }
         }
 
-        return Element.super.mouseClicked(event, bl);
+        return GuiEventListener.super.mouseClicked(event, bl);
     }
 
     // TODO
@@ -109,12 +109,12 @@ public class MessageScreenPopup extends AbstractScreenPopup implements Element, 
     }
 
     @Override
-    public SelectionType getType() {
-        return SelectionType.NONE;
+    public NarrationPriority narrationPriority() {
+        return NarrationPriority.NONE;
     }
 
     @Override
-    public void appendNarrations(NarrationMessageBuilder builder) {
-        builder.put(NarrationPart.TITLE, this.title);
+    public void updateNarration(NarrationElementOutput builder) {
+        builder.add(NarratedElementType.TITLE, this.title);
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/popup/ProgressBarScreenPopup.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/popup/ProgressBarScreenPopup.java
@@ -1,8 +1,8 @@
 package me.bymartrixx.vtd.gui.popup;
 
 import me.bymartrixx.vtd.util.RenderUtil;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 import java.util.function.Supplier;
 
@@ -17,7 +17,7 @@ public class ProgressBarScreenPopup extends AbstractScreenPopup {
 
     private boolean aborted;
 
-    public ProgressBarScreenPopup(MinecraftClient client, int centerX, int centerY, int width, int height, int color) {
+    public ProgressBarScreenPopup(Minecraft client, int centerX, int centerY, int width, int height, int color) {
         super(client, centerX, centerY, width, height);
 
         this.color = color;
@@ -50,7 +50,7 @@ public class ProgressBarScreenPopup extends AbstractScreenPopup {
     }
 
     @Override
-    protected void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    protected void renderContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         float p = this.progress.get();
         if (p < 0.0F) {
             return;

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/CategoryButtonWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/CategoryButtonWidget.java
@@ -2,43 +2,43 @@ package me.bymartrixx.vtd.gui.widget;
 
 import me.bymartrixx.vtd.data.Category;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.client.gui.widget.ClickableWidgetStateTextures;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.WidgetSprites;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.client.sound.PositionedSoundInstance;
-import net.minecraft.client.sound.SoundManager;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
 // Doesn't extend ButtonWidget to allow dynamic positioning
-public class CategoryButtonWidget implements Element, Selectable {
+public class CategoryButtonWidget implements GuiEventListener, NarratableEntry {
     private static final int TEXTURE_HEIGHT = 20;
     private static final int TEXTURE_V_OFFSET = 46;
-    private static final ClickableWidgetStateTextures TEXTURES = new ClickableWidgetStateTextures(
-            Identifier.ofDefault("widget/button"), Identifier.ofDefault("widget/button_disabled"), Identifier.ofDefault("widget/button_highlighted")
+    private static final WidgetSprites TEXTURES = new WidgetSprites(
+            Identifier.withDefaultNamespace("widget/button"), Identifier.withDefaultNamespace("widget/button_disabled"), Identifier.withDefaultNamespace("widget/button_highlighted")
     );
 
     private final Category category;
     private final int width;
     private final int height;
-    private final Text text;
+    private final Component text;
     private final VTDownloadScreen screen;
     private boolean selected = false;
     private boolean hovered;
     private boolean focused;
 
-    public CategoryButtonWidget(VTDownloadScreen screen, int width, int height, Text text, Category category) {
+    public CategoryButtonWidget(VTDownloadScreen screen, int width, int height, Component text, Category category) {
         this.screen = screen;
         this.width = width;
         this.height = height;
@@ -46,26 +46,26 @@ public class CategoryButtonWidget implements Element, Selectable {
         this.category = category;
     }
 
-    public void render(GuiGraphics graphics, int x, int y, int mouseX, int mouseY, float delta) {
+    public void render(GuiGraphicsExtractor graphics, int x, int y, int mouseX, int mouseY, float delta) {
         this.hovered = mouseX >= x && mouseY >= y && mouseX < x + this.width && mouseY < y + this.height;
         this.renderButton(graphics, x, y);
     }
 
-    public void renderButton(GuiGraphics graphics, int x, int y) {
-        MinecraftClient client = MinecraftClient.getInstance();
-        TextRenderer textRenderer = client.textRenderer;
+    public void renderButton(GuiGraphicsExtractor graphics, int x, int y) {
+        Minecraft client = Minecraft.getInstance();
+        Font textRenderer = client.font;
 
         // drawSprite
-        graphics.method_52706(RenderPipelines.GUI_TEXTURED, TEXTURES.getTexture(!this.selected, this.isHoveredOrFocused()), x, y, this.width, this.height);
+        graphics.blitSprite(RenderPipelines.GUI_TEXTURED, TEXTURES.get(!this.selected, this.isHoveredOrFocused()), x, y, this.width, this.height);
 
         int textColor = this.selected ? 0xFFA0A0A0 : 0xFFFFFFFF;
-        graphics.drawCenteredShadowedText(textRenderer, this.text, x + this.width / 2, y + (this.height - 8) / 2, textColor);
+        graphics.centeredText(textRenderer, this.text, x + this.width / 2, y + (this.height - 8) / 2, textColor);
     }
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-        if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1 && this.hovered && !this.selected) {
-            this.playDownSound(MinecraftClient.getInstance().getSoundManager());
+        if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1 && this.hovered && !this.selected) {
+            this.playDownSound(Minecraft.getInstance().getSoundManager());
             return this.screen.selectCategory(this.category);
         }
 
@@ -80,11 +80,11 @@ public class CategoryButtonWidget implements Element, Selectable {
         }
 
         if (keyCode == GLFW.GLFW_KEY_ENTER || keyCode == GLFW.GLFW_KEY_SPACE || keyCode == GLFW.GLFW_KEY_KP_ENTER) {
-            this.playDownSound(MinecraftClient.getInstance().getSoundManager());
+            this.playDownSound(Minecraft.getInstance().getSoundManager());
             return this.screen.selectCategory(this.category);
         }
 
-        return Element.super.keyPressed(event);
+        return GuiEventListener.super.keyPressed(event);
     }
 
     // TODO
@@ -103,28 +103,28 @@ public class CategoryButtonWidget implements Element, Selectable {
     }
 
     private void playDownSound(SoundManager soundManager) {
-        soundManager.play(PositionedSoundInstance.create(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+        soundManager.play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
     }
 
     @Override
-    public SelectionType getType() {
+    public NarrationPriority narrationPriority() {
         if (this.focused) {
-            return SelectionType.FOCUSED;
+            return NarrationPriority.FOCUSED;
         } else if (this.hovered) {
-            return SelectionType.HOVERED;
+            return NarrationPriority.HOVERED;
         }
 
-        return SelectionType.NONE;
+        return NarrationPriority.NONE;
     }
 
     @Override
-    public void appendNarrations(NarrationMessageBuilder builder) {
-        builder.put(NarrationPart.TITLE, ClickableWidget.getNarrationMessage(this.text));
+    public void updateNarration(NarrationElementOutput builder) {
+        builder.add(NarratedElementType.TITLE, AbstractWidget.wrapDefaultNarrationMessage(this.text));
         if (!this.selected) {
             if (this.focused) {
-                builder.put(NarrationPart.USAGE, Text.translatable("narration.button.usage.focused"));
+                builder.add(NarratedElementType.USAGE, Component.translatable("narration.button.usage.focused"));
             } else {
-                builder.put(NarrationPart.USAGE, Text.translatable("narration.button.usage.hovered"));
+                builder.add(NarratedElementType.USAGE, Component.translatable("narration.button.usage.hovered"));
             }
         }
     }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/CategorySelectionWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/CategorySelectionWidget.java
@@ -3,20 +3,20 @@ package me.bymartrixx.vtd.gui.widget;
 import me.bymartrixx.vtd.data.Category;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
 import me.bymartrixx.vtd.util.RenderUtil;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.AbstractParentElement;
-import net.minecraft.client.gui.Drawable;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.AbstractContainerEventHandler;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.MathHelper;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
 import org.joml.Matrix3x2fStack;
 import org.lwjgl.glfw.GLFW;
 
@@ -25,12 +25,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CategorySelectionWidget extends AbstractParentElement implements Drawable, Selectable {
+public class CategorySelectionWidget extends AbstractContainerEventHandler implements Renderable, NarratableEntry {
     // DEBUG
     private static final boolean SHOW_DEBUG_INFO = false;
 
-    private static final Identifier BACKGROUND_TEXTURE = Identifier.ofDefault("textures/gui/menu_list_background.png");
-    private static final Identifier INWORLD_BACKGROUND_TEXTURE = Identifier.ofDefault("textures/gui/inworld_menu_list_background.png");
+    private static final Identifier BACKGROUND_TEXTURE = Identifier.withDefaultNamespace("textures/gui/menu_list_background.png");
+    private static final Identifier INWORLD_BACKGROUND_TEXTURE = Identifier.withDefaultNamespace("textures/gui/inworld_menu_list_background.png");
     private static final int BACKGROUND_TEXTURE_SIZE = 32;
 
     private static final int LEFT_RIGHT_PADDING = 2;
@@ -98,7 +98,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
             return this.categoryButtons.get(category);
         }
 
-        Text text = Text.literal(category.getName());
+        Component text = Component.literal(category.getName());
         CategoryButtonWidget button = new CategoryButtonWidget(this.screen, BUTTON_WIDTH, BUTTON_HEIGHT, text, category);
         this.categoryButtons.put(category, button);
         return button;
@@ -158,7 +158,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
     }
 
     private void setScrollAmount(double scrollAmount) {
-        this.scrollAmount = MathHelper.clamp(scrollAmount, 0.0, this.getMaxScroll());
+        this.scrollAmount = Mth.clamp(scrollAmount, 0.0, this.getMaxScroll());
     }
 
     private void updateScrollingState(double mouseX, double mouseY, int button) {
@@ -193,7 +193,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
     // region input callbacks
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-        this.updateScrollingState(event.x(), event.y(), event.method_74245());
+        this.updateScrollingState(event.x(), event.y(), event.button());
 
         if (!this.isMouseOver(event.x(), event.y())) {
             return false;
@@ -209,7 +209,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
 
     @Override
     public boolean mouseDragged(MouseButtonEvent event, double deltaX, double deltaY) {
-        if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1 && this.scrolling) {
+        if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1 && this.scrolling) {
             // Dragging scrollbar
             if (event.x() < this.left) {
                 this.setScrollAmount(0);
@@ -219,7 +219,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
                 double maxScroll = Math.max(1, this.getMaxScroll());
                 int width = this.getScrollbarEndX() - this.getScrollbarStartX();
                 int barSize = (this.width * this.width) / this.getButtonsWidth();
-                barSize = MathHelper.clamp(barSize, SCROLLBAR_MIN_WIDTH, width);
+                barSize = Mth.clamp(barSize, SCROLLBAR_MIN_WIDTH, width);
 
                 double factor = Math.max(1, maxScroll / (this.width - barSize));
 
@@ -250,7 +250,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
 
     // region render
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         this.renderListBackground(graphics);
         graphics.enableScissor(this.left, this.top, this.right, this.bottom);
         this.renderCategories(graphics, mouseX, mouseY, delta);
@@ -260,14 +260,14 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
     }
 
     // @see EntryListWidget#drawBackground
-    private void renderListBackground(GuiGraphics graphics) {
-        Identifier texture = MinecraftClient.getInstance().world == null ? BACKGROUND_TEXTURE : INWORLD_BACKGROUND_TEXTURE;
-        graphics.method_25290(RenderPipelines.GUI_TEXTURED, texture,
+    private void renderListBackground(GuiGraphicsExtractor graphics) {
+        Identifier texture = Minecraft.getInstance().level == null ? BACKGROUND_TEXTURE : INWORLD_BACKGROUND_TEXTURE;
+        graphics.blit(RenderPipelines.GUI_TEXTURED, texture,
                 this.left, this.top, this.right + (int) this.getScrollAmount(), this.bottom,
                 this.width, this.height, BACKGROUND_TEXTURE_SIZE, BACKGROUND_TEXTURE_SIZE);
     }
 
-    private void renderCategories(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    private void renderCategories(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         for (int i = 0; i < this.children.size(); i++) {
             CategoryButtonWidget button = this.children.get(i);
             int left = getButtonLeft(i);
@@ -280,20 +280,20 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
         }
     }
 
-    private void renderSeparators(GuiGraphics graphics) {
-        Matrix3x2fStack matrices = graphics.getMatrices();
+    private void renderSeparators(GuiGraphicsExtractor graphics) {
+        Matrix3x2fStack matrices = graphics.pose();
         matrices.pushMatrix();
         matrices.rotate((float) Math.PI / 2.0f); // 90 degrees
 
-        Identifier leftSeparator = MinecraftClient.getInstance().world == null ? Screen.FOOTER_SEPARATOR : Screen.INWORLD_FOOTER_SEPARATOR;
-        Identifier rightSeparator = MinecraftClient.getInstance().world == null ? Screen.HEADER_SEPARATOR : Screen.INWORLD_HEADER_SEPARATOR;
-        graphics.method_25290(RenderPipelines.GUI_TEXTURED, leftSeparator, this.top, -this.left, 0.0f, 0.0f, this.height, 2, 32, 2);
-        graphics.method_25290(RenderPipelines.GUI_TEXTURED, rightSeparator, this.top, -this.right - 2, 0.0f, 0.0f, this.height, 2, 32, 2);
+        Identifier leftSeparator = Minecraft.getInstance().level == null ? Screen.FOOTER_SEPARATOR : Screen.INWORLD_FOOTER_SEPARATOR;
+        Identifier rightSeparator = Minecraft.getInstance().level == null ? Screen.HEADER_SEPARATOR : Screen.INWORLD_HEADER_SEPARATOR;
+        graphics.blit(RenderPipelines.GUI_TEXTURED, leftSeparator, this.top, -this.left, 0.0f, 0.0f, this.height, 2, 32, 2);
+        graphics.blit(RenderPipelines.GUI_TEXTURED, rightSeparator, this.top, -this.right - 2, 0.0f, 0.0f, this.height, 2, 32, 2);
 
         matrices.popMatrix();
     }
 
-    private void renderScrollbar(GuiGraphics graphics) {
+    private void renderScrollbar(GuiGraphicsExtractor graphics) {
         if (this.shouldHaveScrollbar()) {
             int startX = this.getScrollbarStartX();
             int endX = this.getScrollbarEndX();
@@ -302,7 +302,7 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
 
             int width = endX - startX;
             int size = (this.width * this.width) / this.getButtonsWidth();
-            size = MathHelper.clamp(size, SCROLLBAR_MIN_WIDTH, width);
+            size = Mth.clamp(size, SCROLLBAR_MIN_WIDTH, width);
 
             int x = (int) this.getScrollAmount() * (width - size) / this.getMaxScroll() + startX;
             if (x < startX) {
@@ -315,10 +315,10 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
         }
     }
 
-    public void renderDebugInfo(GuiGraphics graphics) {
+    public void renderDebugInfo(GuiGraphicsExtractor graphics) {
         if (!SHOW_DEBUG_INFO) return;
-        MinecraftClient client = MinecraftClient.getInstance();
-        TextRenderer textRenderer = client.textRenderer;
+        Minecraft client = Minecraft.getInstance();
+        Font textRenderer = client.font;
 
         int last = categories.size() - 1;
         List<String> debugInfo = List.of(
@@ -364,16 +364,16 @@ public class CategorySelectionWidget extends AbstractParentElement implements Dr
     // endregion
 
     @Override
-    public void appendNarrations(NarrationMessageBuilder builder) {
+    public void updateNarration(NarrationElementOutput builder) {
     }
 
     @Override
-    public List<? extends Element> children() {
+    public List<? extends GuiEventListener> children() {
         return this.children;
     }
 
     @Override
-    public SelectionType getType() {
-        return SelectionType.NONE;
+    public NarrationPriority narrationPriority() {
+        return NarrationPriority.NONE;
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/DebugButtonWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/DebugButtonWidget.java
@@ -1,16 +1,16 @@
 package me.bymartrixx.vtd.gui.widget;
 
-import net.minecraft.text.Text;
+import net.minecraft.network.chat.Component;
 
 public class DebugButtonWidget extends ReloadButtonWidget {
-    private static final Text ICON = Text.literal("\uD83D\uDC1B"); // Bug 🐛
+    private static final Component ICON = Component.literal("\uD83D\uDC1B"); // Bug 🐛
 
-    public DebugButtonWidget(int x, int y, Text message, PressAction onPress) {
+    public DebugButtonWidget(int x, int y, Component message, OnPress onPress) {
         super(x, y, message, onPress);
     }
 
     @Override
-    protected Text getIconText() {
+    protected Component getIconText() {
         return ICON;
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/ExpandDrawerButtonWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/ExpandDrawerButtonWidget.java
@@ -1,19 +1,19 @@
 package me.bymartrixx.vtd.gui.widget;
 
-import net.minecraft.client.gui.Drawable;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.resources.Identifier;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.function.Consumer;
 
-public class ExpandDrawerButtonWidget implements Element, Drawable, Selectable {
-    private static final Identifier TEXTURE = Identifier.of("vt_downloader", "textures/drawer_tab.png");
+public class ExpandDrawerButtonWidget implements GuiEventListener, Renderable, NarratableEntry {
+    private static final Identifier TEXTURE = Identifier.fromNamespaceAndPath("vt_downloader", "textures/drawer_tab.png");
     private static final int TEXTURE_WIDTH = 32;
     private static final int TEXTURE_HEIGHT = 64;
     public static final int TAB_WIDTH = 16;
@@ -43,13 +43,13 @@ public class ExpandDrawerButtonWidget implements Element, Drawable, Selectable {
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-        if (this.isMouseOver(event.x(), event.y()) && event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1) {
+        if (this.isMouseOver(event.x(), event.y()) && event.button() == GLFW.GLFW_MOUSE_BUTTON_1) {
             this.extended = !this.extended;
             this.callback.accept(this.extended);
             return true;
         }
 
-        return Element.super.mouseClicked(event, bl);
+        return GuiEventListener.super.mouseClicked(event, bl);
     }
 
     // TODO
@@ -69,21 +69,21 @@ public class ExpandDrawerButtonWidget implements Element, Drawable, Selectable {
     }
 
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         boolean hovered = mouseX >= this.getLeft() && mouseX < this.getRight()
                 && mouseY >= this.y && mouseY < this.y + TAB_HEIGHT;
         float u = hovered ? TAB_WIDTH : 0.0F;
         float v = this.extended ? TAB_HEIGHT : 0.0F;
         // drawTexture
-        graphics.method_25290(RenderPipelines.GUI_TEXTURED, TEXTURE, this.getLeft(), this.y, u, v, TAB_WIDTH, TAB_HEIGHT, TEXTURE_WIDTH, TEXTURE_HEIGHT);
+        graphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.getLeft(), this.y, u, v, TAB_WIDTH, TAB_HEIGHT, TEXTURE_WIDTH, TEXTURE_HEIGHT);
     }
 
     @Override
-    public SelectionType getType() {
-        return SelectionType.NONE;
+    public NarrationPriority narrationPriority() {
+        return NarrationPriority.NONE;
     }
 
     @Override
-    public void appendNarrations(NarrationMessageBuilder builder) {
+    public void updateNarration(NarrationElementOutput builder) {
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/MutableMessageButtonWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/MutableMessageButtonWidget.java
@@ -1,14 +1,14 @@
 package me.bymartrixx.vtd.gui.widget;
 
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.network.chat.Component;
 
-public class MutableMessageButtonWidget extends ButtonWidget.C_yzicpkhx {
-    private final Text defaultMessage;
-    private Text currentMessage;
+public class MutableMessageButtonWidget extends Button.Plain {
+    private final Component defaultMessage;
+    private Component currentMessage;
 
-    public MutableMessageButtonWidget(int x, int y, int width, int height, Text message, PressAction onPress) {
-        super(x, y, width, height, message, onPress, ButtonWidget.DEFAULT_NARRATION);
+    public MutableMessageButtonWidget(int x, int y, int width, int height, Component message, OnPress onPress) {
+        super(x, y, width, height, message, onPress, Button.DEFAULT_NARRATION);
         this.defaultMessage = message;
         this.currentMessage = message;
     }
@@ -17,12 +17,12 @@ public class MutableMessageButtonWidget extends ButtonWidget.C_yzicpkhx {
         this.currentMessage = this.defaultMessage;
     }
 
-    public void setMessage(Text message) {
+    public void setMessage(Component message) {
         this.currentMessage = message;
     }
 
     @Override
-    public Text getMessage() {
+    public Component getMessage() {
         return this.currentMessage;
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/PackNameTextFieldWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/PackNameTextFieldWidget.java
@@ -1,10 +1,10 @@
 package me.bymartrixx.vtd.gui.widget;
 
 import me.bymartrixx.vtd.util.RenderUtil;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Files;
@@ -12,15 +12,15 @@ import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-public class PackNameTextFieldWidget extends TextFieldWidget {
+public class PackNameTextFieldWidget extends EditBox {
     public static final String FILE_NAME_REGEX = "^[\\w,.\\s-]+$";
     private static final Pattern RESERVED_WINDOWS_NAME = Pattern.compile("^(?:COM|CLOCK\\$|CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\\..*)?$", Pattern.CASE_INSENSITIVE);
     private static final Pattern INVALID_WINDOWS_NAME = Pattern.compile("^.*\\.$");
 
-    private static final Text FILE_EXISTS_TEXT = Text.translatable("vtd.fileNameValidity.fileExists");
-    private static final Text INVALID_WINDOWS_NAME_TEXT = Text.translatable("vtd.fileNameValidity.invalidWindows");
-    private static final Text RESERVED_WINDOWS_NAME_TEXT = Text.translatable("vtd.fileNameValidity.reservedWindows");
-    private static final Text REGEX_DOESNT_MATCH_TEXT = Text.translatable("vtd.fileNameValidity.regexDoesntMatch", FILE_NAME_REGEX);
+    private static final Component FILE_EXISTS_TEXT = Component.translatable("vtd.fileNameValidity.fileExists");
+    private static final Component INVALID_WINDOWS_NAME_TEXT = Component.translatable("vtd.fileNameValidity.invalidWindows");
+    private static final Component RESERVED_WINDOWS_NAME_TEXT = Component.translatable("vtd.fileNameValidity.reservedWindows");
+    private static final Component REGEX_DOESNT_MATCH_TEXT = Component.translatable("vtd.fileNameValidity.regexDoesntMatch", FILE_NAME_REGEX);
 
     public static final int MAX_LENGTH = 64;
     private static final int ERROR_COLOR = 0xFFEA5146;
@@ -28,28 +28,28 @@ public class PackNameTextFieldWidget extends TextFieldWidget {
     private static final int WARNING_COLOR = 0xFFF2B50C;
     private static final int WARNING_FOCUSED_COLOR = 0xFFFFEF0F;
 
-    private final TextRenderer textRenderer; // TextFieldWidget#textRenderer is private
+    private final Font textRenderer; // TextFieldWidget#textRenderer is private
     private final Path directory;
     private final String defaultName;
     private NameStatus nameStatus = NameStatus.VALID;
 
-    public PackNameTextFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, @Nullable String copyText, Text text, Path directory, @Nullable String defaultName) {
+    public PackNameTextFieldWidget(Font textRenderer, int x, int y, int width, int height, @Nullable String copyText, Component text, Path directory, @Nullable String defaultName) {
         super(textRenderer, x, y, width, height, text);
         this.textRenderer = textRenderer;
         this.directory = directory;
         this.defaultName = defaultName;
 
-        super.setChangedListener(this::onChange);
+        super.setResponder(this::onChange);
         this.setMaxLength(MAX_LENGTH);
 
         if (copyText != null) {
-            this.setText(copyText);
+            this.setValue(copyText);
         }
     }
 
     @Override
-    public void setChangedListener(Consumer<String> changedListener) {
-        super.setChangedListener(((Consumer<String>) this::onChange).andThen(changedListener));
+    public void setResponder(Consumer<String> changedListener) {
+        super.setResponder(((Consumer<String>) this::onChange).andThen(changedListener));
     }
 
     private void onChange(String text) {
@@ -71,7 +71,7 @@ public class PackNameTextFieldWidget extends TextFieldWidget {
     }
 
     public boolean isBlank() {
-        return this.getText().isBlank();
+        return this.getValue().isBlank();
     }
 
     public boolean canUseName() {
@@ -79,11 +79,11 @@ public class PackNameTextFieldWidget extends TextFieldWidget {
     }
 
     private boolean isNewName() {
-        return this.defaultName == null || !this.defaultName.equals(this.getText());
+        return this.defaultName == null || !this.defaultName.equals(this.getValue());
     }
 
     @Nullable
-    public Text getTooltipText() {
+    public Component getTooltipText() {
         return switch (this.nameStatus) {
             case FILE_EXISTS -> this.isNewName() ? FILE_EXISTS_TEXT : null;
             case RESERVED_WINDOWS -> RESERVED_WINDOWS_NAME_TEXT;
@@ -94,21 +94,21 @@ public class PackNameTextFieldWidget extends TextFieldWidget {
     }
 
     @Override
-    public void drawWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.drawWidget(graphics, mouseX, mouseY, delta);
+    public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
 
         if (this.isVisible()) {
-            if (this.getText().isEmpty()) {
+            if (this.getValue().isEmpty()) {
                 int x = this.getX() + 4;
                 int y = this.getY() + (this.height - 8) / 2;
-                graphics.drawShadowedText(this.textRenderer, this.getMessage(), x, y, 0x707070);
+                graphics.text(this.textRenderer, this.getMessage(), x, y, 0x707070);
             }
 
             this.renderOutline(graphics);
         }
     }
 
-    private void renderOutline(GuiGraphics graphics) {
+    private void renderOutline(GuiGraphicsExtractor graphics) {
         int color = -1;
         if (this.nameStatus.isError()) {
             color = this.isFocused() ? ERROR_FOCUSED_COLOR : ERROR_COLOR;

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/PackSelectionListWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/PackSelectionListWidget.java
@@ -1,6 +1,5 @@
 package me.bymartrixx.vtd.gui.widget;
 
-import com.mojang.blaze3d.texture.NativeImage;
 import me.bymartrixx.vtd.VTDMod;
 import me.bymartrixx.vtd.access.TextureManagerAccess;
 import me.bymartrixx.vtd.data.Category;
@@ -9,30 +8,30 @@ import me.bymartrixx.vtd.gui.VTDownloadScreen;
 import me.bymartrixx.vtd.util.Constants;
 import me.bymartrixx.vtd.util.RenderUtil;
 import me.bymartrixx.vtd.util.Util;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.MultilineText;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.gui.widget.list.EntryListWidget;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ActiveTextCollector;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.TextAlignment;
+import net.minecraft.client.gui.components.AbstractSelectionList;
+import net.minecraft.client.gui.components.MultiLineLabel;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.KeyEvent;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.client.sound.PositionedSoundInstance;
-import net.minecraft.client.sound.SoundManager;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.client.texture.NativeImageBackedTexture;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.unmapped.C_emchntzr;
-import net.minecraft.unmapped.C_gitqeeaa;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.Identifier;
+import net.minecraft.sounds.SoundEvents;
 import org.lwjgl.glfw.GLFW;
-
+import com.mojang.blaze3d.platform.NativeImage;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,17 +40,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWidget.AbstractEntry> {
+public class PackSelectionListWidget extends AbstractSelectionList<PackSelectionListWidget.AbstractEntry> {
     // DEBUG
     private static final boolean SHOW_DEBUG_INFO = false;
     private static final boolean DEBUG_ERROR_TEXT = false;
     private static final boolean DISABLE_ICONS = false;
 
-    private static final Text ERROR_URL = Util.urlText(VTDMod.BASE_URL);
-    private static final Text ERROR_HEADER = Text.translatable("vtd.packError.title")
-            .formatted(Formatting.BOLD, Formatting.ITALIC);
-    private static final Text ERROR_BODY = Text.translatable("vtd.packError.body", ERROR_URL);
-    private static final Text ERROR_TEXT = Text.empty().append(ERROR_HEADER).append("\n").append(ERROR_BODY);
+    private static final Component ERROR_URL = Util.urlText(VTDMod.BASE_URL);
+    private static final Component ERROR_HEADER = Component.translatable("vtd.packError.title")
+            .withStyle(ChatFormatting.BOLD, ChatFormatting.ITALIC);
+    private static final Component ERROR_BODY = Component.translatable("vtd.packError.body", ERROR_URL);
+    private static final Component ERROR_TEXT = Component.empty().append(ERROR_HEADER).append("\n").append(ERROR_BODY);
 
     public static final int ITEM_HEIGHT = 48;
     private static final int WARNING_MARGIN = 6;
@@ -68,18 +67,18 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     private Category category;
     private boolean editable = true;
 
-    private final MultilineText errorText;
+    private final MultiLineLabel errorText;
 
     private final PackSelectionHelper selectionHelper;
 
-    public PackSelectionListWidget(MinecraftClient client, VTDownloadScreen screen, int width, int height, int y,
+    public PackSelectionListWidget(Minecraft client, VTDownloadScreen screen, int width, int height, int y,
                                    Category category, PackSelectionHelper selectionHelper) {
         super(client, width, height, y, ITEM_HEIGHT);
         this.screen = screen;
         this.category = category;
         this.selectionHelper = selectionHelper;
 
-        this.errorText = Util.createMultilineText(client.textRenderer, ERROR_TEXT, 8, (int) (width / 1.5));
+        this.errorText = Util.createMultilineText(client.font, ERROR_TEXT, 8, (int) (width / 1.5));
 
         // In 1.21.10+, children() returns an unmodifiable collection
         this.replaceEntries(this.getPackEntries(category));
@@ -88,9 +87,9 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     public void setCategory(Category category) {
         this.category = category;
 
-        this.setFocusedChild(null);
+        this.setFocused(null);
         this.replaceEntries(this.getPackEntries(category));
-        this.method_44382(0.0);
+        this.setScrollAmount(0.0);
     }
 
     public void updateCategories(List<Category> categories) {
@@ -179,8 +178,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         return this.getY() + this.height / 2;
     }
 
-    private static int getLineHeight(TextRenderer textRenderer) {
-        return textRenderer.fontHeight + TEXT_MARGIN;
+    private static int getLineHeight(Font textRenderer) {
+        return textRenderer.lineHeight + TEXT_MARGIN;
     }
 
     public void updateScreenWidth() {
@@ -207,7 +206,7 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     }
 
     @Override
-    protected int method_65507() {
+    protected int scrollBarX() {
         return this.getX() + this.getRowWidth() + ROW_LEFT_RIGHT_MARGIN + SCROLLBAR_LEFT_MARGIN;
     }
 
@@ -246,42 +245,42 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     //     }
     // }
 
-    void visitLines(C_gitqeeaa textCollector) {
+    void visitLines(ActiveTextCollector textCollector) {
         if (!this.children().isEmpty()) {
             return;
         }
 
         // visit error lines
-        TextRenderer textRenderer = this.client.textRenderer;
+        Font textRenderer = this.minecraft.font;
 
         int x = this.getCenterX();
         int y = this.getCenterY();
         int lineHeight = getLineHeight(textRenderer);
 
         int textY = y - lineHeight * 2;
-        C_emchntzr alignment = C_emchntzr.CENTER;
-        this.errorText.method_75816(alignment, x, textY, lineHeight, textCollector);
+        TextAlignment alignment = TextAlignment.CENTER;
+        this.errorText.visitLines(alignment, x, textY, lineHeight, textCollector);
     }
 
     // region input callbacks
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-        if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1 && this.children().isEmpty()) {
+        if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1 && this.children().isEmpty()) {
             // Handle clicks when the error is shown
             double mouseX = event.x();
             double mouseY = event.y();
-            if (mouseX >= this.getX() && mouseX < this.getXEnd()
-                    && mouseY >= this.getY() && mouseY < this.getYEnd()) {
-                TextRenderer textRenderer = this.client.textRenderer;
+            if (mouseX >= this.getX() && mouseX < this.getRight()
+                    && mouseY >= this.getY() && mouseY < this.getBottom()) {
+                Font textRenderer = this.minecraft.font;
 
-                C_gitqeeaa.C_abiemazc styleFinder = new C_gitqeeaa.C_abiemazc(textRenderer, (int) mouseX, (int) mouseY);
+                ActiveTextCollector.ClickableStyleFinder styleFinder = new ActiveTextCollector.ClickableStyleFinder(textRenderer, (int) mouseX, (int) mouseY);
                 this.visitLines(styleFinder);
-                Style style = styleFinder.method_75777();
+                Style style = styleFinder.result();
 
                 if (style != null && style.getClickEvent() != null
-                        && style.getClickEvent().getAction() == ClickEvent.Action.OPEN_URL) {
+                        && style.getClickEvent().action() == ClickEvent.Action.OPEN_URL) {
                     URI uri = ((ClickEvent.OpenUrl) style.getClickEvent()).uri();
-                    Util.openUri(this.client, this.screen, uri);
+                    Util.openUri(this.minecraft, this.screen, uri);
 
                     return true;
                 }
@@ -322,8 +321,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
 
     // region render
     @Override
-    public void drawWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.drawWidget(graphics, mouseX, mouseY, delta);
+    public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
 
         if (this.children().isEmpty()) {
             this.renderError(graphics);
@@ -331,7 +330,7 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     }
 
     @Override
-    protected void renderEntry(GuiGraphics graphics, int mouseX, int mouseY, float delta, AbstractEntry entry) {
+    protected void extractItem(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta, AbstractEntry entry) {
         boolean focused = this.isFocused() && this.getFocused() == entry;
         boolean isSelected = entry instanceof PackEntry packEntry && packEntry.selectionData.isSelected();
         if (isSelected) {
@@ -346,10 +345,10 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             RenderUtil.drawOutline(graphics, x - 1, y - 1, width - 2, height - 2, 1, 0xFFFFFFFF);*/
         }
 
-        entry.method_25343(graphics, mouseX, mouseY, Objects.equals(this.getHoveredEntry(), entry), delta);
+        entry.extractContent(graphics, mouseX, mouseY, Objects.equals(this.getHovered(), entry), delta);
     }
 
-    protected void drawEntrySelectionHighlight(GuiGraphics graphics, AbstractEntry entry, int borderColor, int fillColor) {
+    protected void drawEntrySelectionHighlight(GuiGraphicsExtractor graphics, AbstractEntry entry, int borderColor, int fillColor) {
         int x1 = entry.getX();
         int y1 = entry.getY();
         int x2 = x1 + entry.getWidth();
@@ -358,13 +357,13 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         graphics.fill(x1 + 1, y1 + 1, x2 - 1, y2 - 1, fillColor);
     }
 
-    private void renderError(GuiGraphics graphics) {
-        this.visitLines(graphics.method_75788());
+    private void renderError(GuiGraphicsExtractor graphics) {
+        this.visitLines(graphics.textRenderer());
     }
 
-    public void renderDebugInfo(GuiGraphics graphics, int mouseX, int mouseY) {
+    public void renderDebugInfo(GuiGraphicsExtractor graphics, int mouseX, int mouseY) {
         if (!SHOW_DEBUG_INFO) return;
-        TextRenderer textRenderer = this.client.textRenderer;
+        Font textRenderer = this.minecraft.font;
 
         boolean hasCategory = this.category != null;
         List<String> debugInfo = List.of(
@@ -379,12 +378,12 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
                 "MX/MY = " + mouseX + "/" + mouseY
         );
 
-        RenderUtil.renderDebugInfo(graphics, textRenderer, this.getX(), this.getYEnd(), debugInfo);
+        RenderUtil.renderDebugInfo(graphics, textRenderer, this.getX(), this.getBottom(), debugInfo);
     }
 
-    public void renderTooltips(GuiGraphics graphics, int mouseX, int mouseY) {
-        if (mouseY >= this.getY() && mouseY < this.getYEnd()
-                && mouseX >= this.getX() && mouseX < this.getXEnd()
+    public void renderTooltips(GuiGraphicsExtractor graphics, int mouseX, int mouseY) {
+        if (mouseY >= this.getY() && mouseY < this.getBottom()
+                && mouseX >= this.getX() && mouseX < this.getRight()
                 && !this.screen.isCoveredByPopup(mouseX, mouseY)) {
             int width = this.getTooltipWidth();
             for (AbstractEntry entry : this.children()) {
@@ -397,13 +396,13 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     // endregion
 
     @Override
-    public void updateNarration(NarrationMessageBuilder builder) {
-        builder.put(NarrationPart.TITLE, Constants.RESOURCE_PACK_SCREEN_SUBTITLE);
+    public void updateWidgetNarration(NarrationElementOutput builder) {
+        builder.add(NarratedElementType.TITLE, Constants.RESOURCE_PACK_SCREEN_SUBTITLE);
     }
 
     public static class PackEntry extends AbstractEntry {
         private final Pack pack;
-        private final Text name;
+        private final Component name;
 
         private final PackSelectionListWidget widget;
         private final Identifier icon;
@@ -412,8 +411,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
 
         private NativeImage downloadedIconImage;
 
-        private List<Text> description;
-        private MultilineText shortDescription;
+        private List<Component> description;
+        private MultiLineLabel shortDescription;
         private int lastDescriptionWidth;
 
         protected PackSelectionData selectionData;
@@ -421,7 +420,7 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         public PackEntry(PackSelectionListWidget widget, Pack pack) {
             super(widget);
             this.pack = pack;
-            this.name = Text.of(pack.getName()).copy().formatted(Formatting.BOLD);
+            this.name = Component.nullToEmpty(pack.getName()).copy().withStyle(ChatFormatting.BOLD);
             this.widget = widget;
 
             this.icon = VTDMod.getIconId(pack);
@@ -431,11 +430,11 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             this.selectionData = new PackSelectionData(this.pack, widget.category);
         }
 
-        protected List<Text> getDescriptionLines(int maxWidth) {
+        protected List<Component> getDescriptionLines(int maxWidth) {
             return this.wrapEscapedText(this.pack.getDescription(), maxWidth);
         }
 
-        private List<Text> getDescription(int maxWidth) {
+        private List<Component> getDescription(int maxWidth) {
             if (this.description != null) {
                 return this.description;
             }
@@ -445,20 +444,20 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             return this.description;
         }
 
-        private MultilineText getShortDescription(int maxWidth, TextRenderer textRenderer) {
+        private MultiLineLabel getShortDescription(int maxWidth, Font textRenderer) {
             if (maxWidth == this.lastDescriptionWidth && this.shortDescription != null) {
                 return this.shortDescription;
             }
 
-            List<Text> fullDescriptionLines =  this.getDescriptionLines(maxWidth);
-            List<Text> lines = new ArrayList<>();
+            List<Component> fullDescriptionLines =  this.getDescriptionLines(maxWidth);
+            List<Component> lines = new ArrayList<>();
             if (!fullDescriptionLines.isEmpty()) {
                 lines.add(fullDescriptionLines.getFirst());
 
                 // truncate the second line at a punctuation
                 if (fullDescriptionLines.size() > 1) {
-                    Text secondLine = fullDescriptionLines.get(1);
-                    int lineWidth = textRenderer.getWidth(secondLine);
+                    Component secondLine = fullDescriptionLines.get(1);
+                    int lineWidth = textRenderer.width(secondLine);
 
                     // If there are more than 2 lines, or if the second line doesn't fit, truncate at last punctuation
                     if (fullDescriptionLines.size() > 2 || lineWidth > maxWidth) {
@@ -482,8 +481,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         private void downloadIcon() {
             if (this.downloadedIconImage != null) {
                 TextureManager textureManager = this.client.getTextureManager();
-                NativeImageBackedTexture iconTexture = new NativeImageBackedTexture(this.pack::getId, this.downloadedIconImage);
-                textureManager.method_4616(this.icon, iconTexture);
+                DynamicTexture iconTexture = new DynamicTexture(this.pack::getId, this.downloadedIconImage);
+                textureManager.register(this.icon, iconTexture);
                 this.iconExists = true;
                 this.downloadedIconImage = null;
             }
@@ -507,13 +506,13 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         }
 
         @Override
-        protected List<Text> getTooltipText(int width) {
+        protected List<Component> getTooltipText(int width) {
             return this.getDescription(width);
         }
 
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-            if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1) {
+            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1) {
                 this.widget.toggleSelection(this);
                 return true;
             }
@@ -523,12 +522,12 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
 
         // region entryRender
         @Override
-        public void method_25343(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
             int x = this.getX();
             int y = this.getY();
             int height = this.getHeight();
             int width = this.getWidth();
-            TextRenderer textRenderer = this.client.textRenderer;
+            Font textRenderer = this.client.font;
             // Keep icon size fixed based on ITEM_HEIGHT, not entryHeight (reduced to 75%)
             int iconSize = ((ITEM_HEIGHT - ICON_MARGIN * 2) * 3)/4;
 
@@ -548,21 +547,21 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             int textStartY = y + (height - totalTextHeight) / 2;
             int centerX = textAreaX + textAreaWidth / 2; // center in text area
 
-            graphics.drawCenteredShadowedText(textRenderer, this.name, centerX, textStartY, 0xFFFFFFFF);
+            graphics.centeredText(textRenderer, this.name, centerX, textStartY, 0xFFFFFFFF);
 
             // Use textAreaWidth for description to ensure proper wrapping when menu is open
             this.renderDescription(graphics, centerX, textStartY + lineHeight, textAreaWidth);
             if (!DISABLE_ICONS) this.renderIcon(graphics, iconX, iconY, iconSize);
         }
 
-        private void renderDescription(GuiGraphics graphics, int x, int y, int width) {
-            TextRenderer textRenderer = this.client.textRenderer;
-            MultilineText description = this.getShortDescription(width - TEXT_MARGIN, textRenderer);
-            C_emchntzr alignment = C_emchntzr.CENTER;
-            description.method_75816(alignment, x, y, textRenderer.fontHeight, graphics.method_75788());
+        private void renderDescription(GuiGraphicsExtractor graphics, int x, int y, int width) {
+            Font textRenderer = this.client.font;
+            MultiLineLabel description = this.getShortDescription(width - TEXT_MARGIN, textRenderer);
+            TextAlignment alignment = TextAlignment.CENTER;
+            description.visitLines(alignment, x, y, textRenderer.lineHeight, graphics.textRenderer());
         }
 
-        private static Text truncateAtLastPunctuation(Text originalText, int maxWidth, TextRenderer textRenderer) {
+        private static Component truncateAtLastPunctuation(Component originalText, int maxWidth, Font textRenderer) {
             String text = originalText.getString();
             int lastPunctIndex = -1;
 
@@ -571,8 +570,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
                 char c = text.charAt(i);
                 if (c == '.' || c == ',') {
                     String candidate = text.substring(0, i + 1);
-                    Text candidateText = Text.of(candidate).copy().setStyle(originalText.getStyle());
-                    if (textRenderer.getWidth(candidateText) <= maxWidth) {
+                    Component candidateText = Component.nullToEmpty(candidate).copy().setStyle(originalText.getStyle());
+                    if (textRenderer.width(candidateText) <= maxWidth) {
                         lastPunctIndex = i + 1;
                         break;
                     }
@@ -582,27 +581,27 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             // If we found a punctuation mark, truncate there
             if (lastPunctIndex > 0) {
                 String truncated = text.substring(0, lastPunctIndex);
-                return Text.of(truncated).copy().setStyle(originalText.getStyle());
+                return Component.nullToEmpty(truncated).copy().setStyle(originalText.getStyle());
             }
 
             // If no punctuation found, truncate to fit maxWidth
             for (int i = text.length(); i > 0; i--) {
                 String candidate = text.substring(0, i);
-                Text candidateText = Text.of(candidate).copy().setStyle(originalText.getStyle());
-                if (textRenderer.getWidth(candidateText) <= maxWidth) {
+                Component candidateText = Component.nullToEmpty(candidate).copy().setStyle(originalText.getStyle());
+                if (textRenderer.width(candidateText) <= maxWidth) {
                     return candidateText;
                 }
             }
 
             // Fallback: return empty or first character
-            return Text.empty();
+            return Component.empty();
         }
 
-        private void renderIcon(GuiGraphics graphics, int x, int y, int size) {
+        private void renderIcon(GuiGraphicsExtractor graphics, int x, int y, int size) {
             downloadIcon();
             if (!this.iconExists) return;
 
-            graphics.method_25290(RenderPipelines.GUI_TEXTURED, this.icon, x, y, 0.0F, 0.0F, size, size, size, size);
+            graphics.blit(RenderPipelines.GUI_TEXTURED, this.icon, x, y, 0.0F, 0.0F, size, size, size, size);
         }
         // endregion
 
@@ -616,8 +615,8 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         private final Category.Warning warning;
         private final int color;
 
-        private List<Text> textLines;
-        private MultilineText text;
+        private List<Component> textLines;
+        private MultiLineLabel text;
 
         public WarningEntry(PackSelectionListWidget widget, Category.Warning warning) {
             super(widget);
@@ -626,11 +625,11 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             this.color = Util.parseColor(warning.getColor());
         }
 
-        private List<Text> getWrappedText(int maxWidth) {
+        private List<Component> getWrappedText(int maxWidth) {
             return this.wrapEscapedText(this.warning.getText(), maxWidth);
         }
 
-        private List<Text> getTextLines(int maxWidth) {
+        private List<Component> getTextLines(int maxWidth) {
             if (this.textLines != null) {
                 return this.textLines;
             }
@@ -639,7 +638,7 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             return this.textLines;
         }
 
-        private MultilineText getText(int maxWidth) {
+        private MultiLineLabel getText(int maxWidth) {
             if (this.text != null) {
                 return this.text;
             }
@@ -649,13 +648,13 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         }
 
         @Override
-        protected List<Text> getTooltipText(int width) {
+        protected List<Component> getTooltipText(int width) {
             return this.getTextLines(width);
         }
 
         // region warningRender
         @Override
-        public void method_25343(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
             int x = this.getX();
             int y = this.getY();
             int width = this.getWidth();
@@ -668,16 +667,16 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
             this.renderText(graphics, x + WARNING_MARGIN + textWidth / 2, y + WARNING_MARGIN, textWidth, textHeight);
         }
 
-        private void renderBackground(GuiGraphics graphics, int x, int y, int width, int height) {
+        private void renderBackground(GuiGraphicsExtractor graphics, int x, int y, int width, int height) {
             graphics.fill(x, y, x + width, y + height, this.color);
         }
 
-        private void renderText(GuiGraphics graphics, int x, int y, int width, int height) {
-            MultilineText text = this.getText(width);
-            C_emchntzr alignment = C_emchntzr.CENTER;
-            int lineHeight = this.client.textRenderer.fontHeight;
-            int textY = y + height / 2 - text.count() * lineHeight / 2;
-            text.method_75816(alignment, x, textY, lineHeight, graphics.method_75788());
+        private void renderText(GuiGraphicsExtractor graphics, int x, int y, int width, int height) {
+            MultiLineLabel text = this.getText(width);
+            TextAlignment alignment = TextAlignment.CENTER;
+            int lineHeight = this.client.font.lineHeight;
+            int textY = y + height / 2 - text.getLineCount() * lineHeight / 2;
+            text.visitLines(alignment, x, textY, lineHeight, graphics.textRenderer());
         }
         // endregion
 
@@ -712,29 +711,29 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
     public abstract static class CategoryButtonEntry extends AbstractEntry {
         protected static final int BUTTON_HEIGHT = 20;
         protected static final int BUTTON_HORIZONTAL_PADDING = 32;
-        protected static final Identifier TEXTURE = Identifier.ofDefault("widget/button");
+        protected static final Identifier TEXTURE = Identifier.withDefaultNamespace("widget/button");
 
         protected final Category category;
-        protected final Text name;
+        protected final Component name;
 
         protected CategoryButtonEntry(PackSelectionListWidget widget, Category category) {
             super(widget);
             this.category = category;
-            this.name = Text.literal(category.getName()).formatted(Formatting.BOLD);
+            this.name = Component.literal(category.getName()).withStyle(ChatFormatting.BOLD);
         }
 
         @Override
-        protected List<Text> getTooltipText(int width) {
+        protected List<Component> getTooltipText(int width) {
             return Collections.emptyList();
         }
 
         private void playDownSound(SoundManager soundManager) {
-            soundManager.play(PositionedSoundInstance.create(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+            soundManager.play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
         }
 
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-            if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1) {
+            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1) {
                 this.screen.selectCategory(this.category);
                 this.playDownSound(this.client.getSoundManager());
                 return true;
@@ -744,44 +743,44 @@ public class PackSelectionListWidget extends EntryListWidget<PackSelectionListWi
         }
 
         @Override
-        public void method_25343(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
             int x = this.getX();
             int y = this.getY();
             int width = this.getWidth();
             int height = this.getHeight();
 
             // drawSprite
-            graphics.method_52706(RenderPipelines.GUI_TEXTURED, TEXTURE,
+            graphics.blitSprite(RenderPipelines.GUI_TEXTURED, TEXTURE,
                     x + BUTTON_HORIZONTAL_PADDING, y + (height - BUTTON_HEIGHT) / 2, width - BUTTON_HORIZONTAL_PADDING * 2, BUTTON_HEIGHT);
-            graphics.drawCenteredShadowedText(this.client.textRenderer, this.name, x + width / 2, y + (height - this.client.textRenderer.fontHeight) / 2, 0xFFFFFFFF);
+            graphics.centeredText(this.client.font, this.name, x + width / 2, y + (height - this.client.font.lineHeight) / 2, 0xFFFFFFFF);
         }
     }
 
-    public static abstract class AbstractEntry extends EntryListWidget.Entry<AbstractEntry> {
+    public static abstract class AbstractEntry extends AbstractSelectionList.Entry<AbstractEntry> {
         protected final PackSelectionListWidget parentWidget;
-        protected final MinecraftClient client;
+        protected final Minecraft client;
         protected final VTDownloadScreen screen;
 
         protected AbstractEntry(PackSelectionListWidget widget) {
             this.parentWidget = widget;
-            this.client = widget.client;
+            this.client = widget.minecraft;
             this.screen = widget.screen;
         }
 
-        protected final List<Text> wrapEscapedText(String text, int maxWidth) {
-            return Util.wrapText(this.client.textRenderer, Util.removeHtmlTags(text), maxWidth);
+        protected final List<Component> wrapEscapedText(String text, int maxWidth) {
+            return Util.wrapText(this.client.font, Util.removeHtmlTags(text), maxWidth);
         }
 
-        protected final MultilineText createMultilineText(List<Text> lines) {
-            return Util.createMultilineText(this.client.textRenderer, lines, 4);
+        protected final MultiLineLabel createMultilineText(List<Component> lines) {
+            return Util.createMultilineText(this.client.font, lines, 4);
         }
 
-        protected abstract List<Text> getTooltipText(int width);
+        protected abstract List<Component> getTooltipText(int width);
 
         // region baseEntryRender
-        protected boolean renderTooltip(GuiGraphics graphics, int mouseX, int mouseY, int width) {
+        protected boolean renderTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY, int width) {
             if (this.isMouseOver(mouseX, mouseY)) {
-                graphics.deferDrawingTooltip(this.client.textRenderer, this.getTooltipText(width), mouseX, mouseY);
+                graphics.setComponentTooltipForNextFrame(this.client.font, this.getTooltipText(width), mouseX, mouseY);
                 return true;
             }
 

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/ReloadButtonWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/ReloadButtonWidget.java
@@ -1,34 +1,34 @@
 package me.bymartrixx.vtd.gui.widget;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.network.chat.Component;
 
-public class ReloadButtonWidget extends ButtonWidget {
-    private static final Text ICON = Text.literal("\u21BB"); // Clockwise arrow ↻
+public class ReloadButtonWidget extends Button {
+    private static final Component ICON = Component.literal("\u21BB");
 
     public static final int BUTTON_SIZE = 20;
 
-    public ReloadButtonWidget(int x, int y, Text message, PressAction onPress) {
-        super(x, y, BUTTON_SIZE, BUTTON_SIZE, message, onPress, ButtonWidget.DEFAULT_NARRATION);
+    public ReloadButtonWidget(int x, int y, Component message, OnPress onPress) {
+        super(x, y, BUTTON_SIZE, BUTTON_SIZE, message, onPress, Button.DEFAULT_NARRATION);
     }
 
-    protected Text getIconText() {
+    protected Component getIconText() {
         return ICON;
     }
 
     @Override
-    protected void method_75752(GuiGraphics graphics, int mouseX, int mouseY, float f) {
-        this.method_75794(graphics);
+    protected void extractContents(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float f) {
+        this.extractDefaultSprite(graphics);
         int scale = 2;
         int centerX = this.width / 2 + this.getX();
 
-        TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
-        graphics.getMatrices().pushMatrix();
-        graphics.getMatrices().scale(scale, scale);
-        graphics.drawCenteredShadowedText(textRenderer, this.getIconText(), centerX / scale, this.getY() / scale, 0xFFFFFFFF);
-        graphics.getMatrices().popMatrix();
+        Font textRenderer = Minecraft.getInstance().font;
+        graphics.pose().pushMatrix();
+        graphics.pose().scale(scale, scale);
+        graphics.centeredText(textRenderer, this.getIconText(), centerX / scale, this.getY() / scale, 0xFFFFFFFF);
+        graphics.pose().popMatrix();
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/gui/widget/SelectedPacksListWidget.java
+++ b/src/main/java/me/bymartrixx/vtd/gui/widget/SelectedPacksListWidget.java
@@ -3,27 +3,27 @@ package me.bymartrixx.vtd.gui.widget;
 import me.bymartrixx.vtd.data.Category;
 import me.bymartrixx.vtd.data.Pack;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.gui.widget.list.EntryListWidget;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractSelectionList;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import net.minecraft.util.Util;
-import net.minecraft.util.math.MathHelper;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWidget.AbstractEntry> {
-    private static final Text HEADER = Text.translatable("vtd.selectedPacks")
-            .formatted(Formatting.BOLD, Formatting.UNDERLINE);
+public class SelectedPacksListWidget extends AbstractSelectionList<SelectedPacksListWidget.AbstractEntry> {
+    private static final Component HEADER = Component.translatable("vtd.selectedPacks")
+            .withStyle(ChatFormatting.BOLD, ChatFormatting.UNDERLINE);
 
     private static final int ITEM_HEIGHT = 16;
     private static final int HEADER_HEIGHT = 16;
@@ -35,7 +35,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
     private final PackSelectionHelper selectionHelper;
     private boolean extended = false;
 
-    public SelectedPacksListWidget(VTDownloadScreen screen, MinecraftClient client, int width, int height, int x, int y,
+    public SelectedPacksListWidget(VTDownloadScreen screen, Minecraft client, int width, int height, int x, int y,
                                    PackSelectionHelper selectionHelper) {
         super(client, width, height, y, ITEM_HEIGHT);
         this.screen = screen;
@@ -43,7 +43,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
         this.setX(x);
         // add the header entry
-        this.method_73370(new HeaderEntry(this), HEADER_HEIGHT);
+        this.addEntry(new HeaderEntry(this), HEADER_HEIGHT);
 
         selectionHelper.addCallback(this::updateSelection);
         this.addPacks(selectionHelper.getSelectedPacks());
@@ -95,7 +95,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
         }
 
         // Update scrollbar
-        this.method_65506();
+        this.refreshScrollAmount();
     }
 
     private void addPacks(Map<Category, List<Pack>> packs) {
@@ -128,12 +128,12 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
                     this.insertEntryAt(index + 1, entry);
                 } else {
                     // Add to end
-                    this.method_25321(entry);
+                    this.addEntry(entry);
                 }
             } else {
                 entry = new CategoryEntry(this, category);
                 // Add to end
-                this.method_25321(entry);
+                this.addEntry(entry);
             }
             return entry;
         }
@@ -228,7 +228,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
     @Override
     public int getRowWidth() {
-        return this.width - ROW_LEFT_RIGHT_MARGIN * 2 - field_55258 - SCROLLBAR_LEFT_MARGIN;
+        return this.width - ROW_LEFT_RIGHT_MARGIN * 2 - SCROLLBAR_WIDTH - SCROLLBAR_LEFT_MARGIN;
     }
 
     @Override
@@ -237,7 +237,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
     }
 
     @Override
-    protected int method_65507() {
+    protected int scrollBarX() {
         return this.getRowRight() + SCROLLBAR_LEFT_MARGIN;
     }
 
@@ -302,28 +302,28 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
     // region render
     @Override
-    public void drawWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+    public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         if (!this.extended) {
             return;
         }
 
-        super.drawWidget(graphics, mouseX, mouseY, delta);
+        super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
     }
     // endregion
 
     @Override
-    public void updateNarration(NarrationMessageBuilder builder) {
-        builder.put(NarrationPart.TITLE, HEADER);
+    public void updateWidgetNarration(NarrationElementOutput builder) {
+        builder.add(NarratedElementType.TITLE, HEADER);
     }
 
     public static abstract class AbstractEntry extends Entry<AbstractEntry> {
-        protected final MinecraftClient client;
+        protected final Minecraft client;
         protected final SelectedPacksListWidget widget;
-        private Text text;
+        private Component text;
         protected String textPrefix = null;
 
         protected AbstractEntry(SelectedPacksListWidget widget) {
-            this.client = widget.client;
+            this.client = widget.minecraft;
             this.widget = widget;
         }
 
@@ -331,12 +331,12 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
         protected abstract void selectEntry();
 
-        protected Text getText() {
+        protected Component getText() {
             if (this.text != null) {
                 return this.text;
             }
 
-            this.text = Text.of(this.getTextString());
+            this.text = Component.nullToEmpty(this.getTextString());
             return this.text;
         }
 
@@ -345,36 +345,36 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
         }
 
         // @see ClickableWidget#drawScrollingText
-        protected void drawScrollingText(GuiGraphics graphics, int x, int y, int maxWidth, int height, int color) {
-            TextRenderer textRenderer = this.client.textRenderer;
-            Text text = this.getText();
-            int textWidth = textRenderer.getWidth(text);
+        protected void drawScrollingText(GuiGraphicsExtractor graphics, int x, int y, int maxWidth, int height, int color) {
+            Font textRenderer = this.client.font;
+            Component text = this.getText();
+            int textWidth = textRenderer.width(text);
 
             if (textWidth > maxWidth) {
                 int extraWidth = textWidth - maxWidth;
-                double seconds = (double) Util.getMeasuringTimeMs() / 1000.0;
+                double seconds = (double) Util.getMillis() / 1000.0;
                 double scrollWidth = Math.max((double) extraWidth * 0.5, 3.0);
                 double delta = Math.sin((Math.PI / 2) * Math.cos((Math.PI * 2) * seconds / scrollWidth)) / 2.0 + 0.5;
-                double scrollOffset = MathHelper.lerp(delta, 0.0, extraWidth);
+                double scrollOffset = Mth.lerp(delta, 0.0, extraWidth);
 
                 graphics.enableScissor(x, y, x + maxWidth, y + height);
-                graphics.drawShadowedText(textRenderer, text, x - (int) scrollOffset, y, color);
+                graphics.text(textRenderer, text, x - (int) scrollOffset, y, color);
                 graphics.disableScissor();
             } else {
-                graphics.drawShadowedText(textRenderer, text, x, y, color);
+                graphics.text(textRenderer, text, x, y, color);
             }
         }
 
         @Override
-        public void method_25343(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
-            TextRenderer textRenderer = this.client.textRenderer;
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+            Font textRenderer = this.client.font;
             int x = this.getX();
             int y = this.getY();
             int width = this.getWidth();
             int height = this.getHeight();
             int color = this.getColor();
-            graphics.drawShadowedString(textRenderer, this.textPrefix, x, y, color);
-            int offsetX = textRenderer.getWidth(this.textPrefix);
+            graphics.text(textRenderer, this.textPrefix, x, y, color);
+            int offsetX = textRenderer.width(this.textPrefix);
             if (offsetX > 0) {
                 this.drawScrollingText(graphics, x + offsetX, y, width - (offsetX - x), height, color);
             } else {
@@ -394,7 +394,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
         }
 
         @Override
-        protected Text getText() {
+        protected Component getText() {
             return HEADER;
         }
 
@@ -403,11 +403,11 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
         }
 
         @Override
-        public void method_25343(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
-            TextRenderer textRenderer = this.client.textRenderer;
+        public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+            Font textRenderer = this.client.font;
             int centerX = this.getX() + this.getWidth() / 2;
-            int centerY = this.getY() + this.getHeight() / 2 - textRenderer.fontHeight / 2;
-            graphics.drawCenteredShadowedText(textRenderer, HEADER, centerX, centerY, this.getColor());
+            int centerY = this.getY() + this.getHeight() / 2 - textRenderer.lineHeight / 2;
+            graphics.centeredText(textRenderer, HEADER, centerX, centerY, this.getColor());
         }
     }
 
@@ -422,7 +422,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-            if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1) {
+            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1) {
                 long time = System.currentTimeMillis();
                 if (time <= this.lastClickTime + DOUBLE_CLICK_THRESHOLD) {
                     this.selectEntry();
@@ -525,7 +525,7 @@ public class SelectedPacksListWidget extends EntryListWidget<SelectedPacksListWi
 
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
-            if (event.method_74245() == GLFW.GLFW_MOUSE_BUTTON_1) {
+            if (event.button() == GLFW.GLFW_MOUSE_BUTTON_1) {
                 long time = System.currentTimeMillis();
                 if (time <= this.lastClickTime + DOUBLE_CLICK_THRESHOLD) {
                     this.selectEntry();

--- a/src/main/java/me/bymartrixx/vtd/mixin/PackEntryListWidgetMixin.java
+++ b/src/main/java/me/bymartrixx/vtd/mixin/PackEntryListWidgetMixin.java
@@ -5,16 +5,13 @@ import me.bymartrixx.vtd.access.PackEntryListWidgetAccess;
 import me.bymartrixx.vtd.access.PackScreenAccess;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
 import me.bymartrixx.vtd.util.Constants;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screen.pack.PackScreen;
-import net.minecraft.client.gui.screen.pack.ResourcePackOrganizer;
-import net.minecraft.client.gui.widget.list.AlwaysSelectedEntryListWidget;
-import net.minecraft.client.gui.widget.list.EntryListWidget;
-import net.minecraft.client.gui.widget.list.pack.PackEntryListWidget;
-import net.minecraft.client.render.RenderPipelines;
-import net.minecraft.text.Text;
-import net.minecraft.text.component.TranslatableComponent;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractSelectionList;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.gui.screens.packs.PackSelectionModel;
+import net.minecraft.client.gui.screens.packs.PackSelectionScreen;
+import net.minecraft.client.gui.screens.packs.TransferableSelectionList;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -24,30 +21,33 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(PackEntryListWidget.class)
-public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWidget<PackEntryListWidget.C_rndhezet>
+@Mixin(TransferableSelectionList.class)
+public abstract class PackEntryListWidgetMixin extends ObjectSelectionList<TransferableSelectionList.Entry>
         implements PackEntryListWidgetAccess {
     @Shadow @Final
-    private Text title;
+    private Component title;
 
     @Shadow @Final
-    PackScreen screen;
+    PackSelectionScreen screen;
 
-    public PackEntryListWidgetMixin(MinecraftClient client, int width, int height, int y, int itemHeight) {
+    public PackEntryListWidgetMixin(Minecraft client, int width, int height, int y, int itemHeight) {
         super(client, width, height, y, itemHeight);
     }
 
     @Override
     public boolean vtdownloader$isAvailablePackList() {
         // Available packs list uses "pack.available.title" as title
-        return this.title.asComponent() instanceof TranslatableComponent c && c.getKey().contains("available");
+        return this.title.getContents() instanceof TranslatableContents c && c.getKey().contains("available");
     }
 
     @Override
     public int vtdownloader$getItemHeight() {
-        return this.field_62109;
+        return this.defaultEntryHeight;
     }
 
     @Override
@@ -56,12 +56,12 @@ public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWi
     }
 
     @Override
-    public PackScreen vtdownloader$getScreen() {
+    public PackSelectionScreen vtdownloader$getScreen() {
         return this.screen;
     }
 
-    @Mixin(PackEntryListWidget.PackEntry.class)
-    public static abstract class PackEntryMixin extends EntryListWidget.Entry<PackEntryListWidget.C_rndhezet> {
+    @Mixin(TransferableSelectionList.PackEntry.class)
+    public static abstract class PackEntryMixin extends AbstractSelectionList.Entry<TransferableSelectionList.Entry> {
         @Unique
         private static final int PENCIL_TEXTURE_SIZE = 32;
         @Unique
@@ -72,11 +72,11 @@ public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWi
         private static final int PENCIL_BOTTOM_MARGIN = 0;
 
         @Shadow @Final
-        private PackEntryListWidget widget;
+        private TransferableSelectionList parent;
         @Shadow @Final
-        protected MinecraftClient client;
+        protected Minecraft minecraft;
         @Shadow @Final
-        private ResourcePackOrganizer.Pack pack;
+        private PackSelectionModel.Entry pack;
 
         @Unique
         private boolean vtdownloader$vtPack;
@@ -94,15 +94,15 @@ public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWi
         }
 
         @Inject(at = @At("TAIL"), method = "<init>")
-        private void vtdownloader$init(PackEntryListWidget outer, MinecraftClient client, PackEntryListWidget widget, ResourcePackOrganizer.Pack pack, CallbackInfo ci) {
+        private void vtdownloader$init(TransferableSelectionList outer, Minecraft client, TransferableSelectionList widget, PackSelectionModel.Entry pack, CallbackInfo ci) {
             if (((PackEntryListWidgetAccess) widget).vtdownloader$isResourcePackList()) {
                 this.vtdownloader$vtPack = pack.getDescription().getString().contains(Constants.VT_DESCRIPTION_MARKER);
-                this.vtdownloader$editable = this.vtdownloader$vtPack && ((PackEntryListWidgetAccess) this.widget).vtdownloader$isAvailablePackList();
+                this.vtdownloader$editable = this.vtdownloader$vtPack && ((PackEntryListWidgetAccess) this.parent).vtdownloader$isAvailablePackList();
             }
         }
 
-        @Inject(at = @At("TAIL"), method = "method_25343")
-        private void renderEditButton(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float tickDelta, CallbackInfo ci) {
+        @Inject(at = @At("TAIL"), method = "extractContent")
+        private void renderEditButton(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float tickDelta, CallbackInfo ci) {
             if (this.vtdownloader$vtPack) {
                 int pencilX = this.getX() + this.vtdownloader$getPencilXOffset();
                 int pencilY = this.getY() + this.vtdownloader$getPencilYOffset();
@@ -124,15 +124,15 @@ public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWi
                 }
 
                 // drawTexture
-                graphics.method_25290(RenderPipelines.GUI_TEXTURED, Constants.PENCIL_TEXTURE, pencilX, pencilY,
+                graphics.blit(RenderPipelines.GUI_TEXTURED, Constants.PENCIL_TEXTURE, pencilX, pencilY,
                         u, v, PENCIL_SIZE, PENCIL_SIZE, PENCIL_TEXTURE_SIZE, PENCIL_TEXTURE_SIZE);
             }
         }
 
-        // @version 1.21.11
+        // @version 26.1
         @Inject(at = @At(
                 value = "INVOKE",
-                target = "Lnet/minecraft/client/gui/screen/pack/ResourcePackOrganizer$Pack;canBeEnabled()Z"
+                target = "Lnet/minecraft/client/gui/screens/packs/PackSelectionModel$Entry;canSelect()Z"
         ), method = "mouseClicked")
         private void onMouseClicked(MouseButtonEvent event, boolean bl, CallbackInfoReturnable<Boolean> cir,
                                     @Local(ordinal = 0) int clickedX, @Local(ordinal = 1) int clickedY) {
@@ -142,9 +142,9 @@ public abstract class PackEntryListWidgetMixin extends AlwaysSelectedEntryListWi
 
                 if (clickedX >= pencilX && clickedX < pencilX + PENCIL_SIZE
                         && clickedY >= pencilY && clickedY < pencilY + PENCIL_SIZE) {
-                    PackScreen screen = ((PackEntryListWidgetAccess) this.widget).vtdownloader$getScreen();
+                    PackSelectionScreen screen = ((PackEntryListWidgetAccess) this.parent).vtdownloader$getScreen();
                     ((PackScreenAccess) screen).vtdownloader$applyChanges();
-                    this.client.setScreen(new VTDownloadScreen(screen,
+                    this.minecraft.setScreen(new VTDownloadScreen(screen,
                             Constants.RESOURCE_PACK_SCREEN_SUBTITLE, this.pack));
                 }
             }

--- a/src/main/java/me/bymartrixx/vtd/mixin/PackScreenMixin.java
+++ b/src/main/java/me/bymartrixx/vtd/mixin/PackScreenMixin.java
@@ -5,12 +5,12 @@ import me.bymartrixx.vtd.access.PackScreenAccess;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
 import me.bymartrixx.vtd.util.Constants;
 import me.bymartrixx.vtd.util.Util;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.pack.PackScreen;
-import net.minecraft.client.gui.screen.pack.ResourcePackOrganizer;
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.client.gui.widget.layout.LinearLayoutWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.packs.PackSelectionModel;
+import net.minecraft.client.gui.screens.packs.PackSelectionScreen;
+import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,35 +23,35 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.nio.file.Path;
 
-@Mixin(PackScreen.class)
+@Mixin(PackSelectionScreen.class)
 public class PackScreenMixin extends Screen implements PackScreenAccess {
     @Shadow
     @Final
-    private Path file;
+    private Path packDir;
 
     @Shadow
     @Final
-    private ResourcePackOrganizer organizer;
+    private PackSelectionModel model;
 
-    protected PackScreenMixin(Text title) {
+    protected PackScreenMixin(Component title) {
         super(title);
     }
 
     /**
      * Add the VT button between the "Open pack folder" and "Done" buttons
      */
-    @Inject(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/layout/LinearLayoutWidget;add(Lnet/minecraft/client/gui/widget/Widget;)Lnet/minecraft/client/gui/widget/Widget;",
+    @Inject(method = "init()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/layouts/LinearLayout;addChild(Lnet/minecraft/client/gui/layouts/LayoutElement;)Lnet/minecraft/client/gui/layouts/LayoutElement;",
             ordinal = 4)) // last invoke
-    private void addVTDButton(CallbackInfo ci, @Local(ordinal = 1) LinearLayoutWidget footerLayout) {
+    private void addVTDButton(CallbackInfo ci, @Local(ordinal = 1) LinearLayout footerLayout) {
         //noinspection ConstantValue
-        if (!this.vtdownloader$isResourcePackScreen() || (Class<?>) this.getClass() != PackScreen.class) {
+        if (!this.vtdownloader$isResourcePackScreen() || (Class<?>) this.getClass() != PackSelectionScreen.class) {
             return;
         }
 
-        footerLayout.add(ButtonWidget.builder(Constants.RESOURCE_PACK_BUTTON_TEXT, btn -> {
+        footerLayout.addChild(Button.builder(Constants.RESOURCE_PACK_BUTTON_TEXT, btn -> {
             this.vtdownloader$applyChanges();
             // noinspection ConstantConditions
-            this.client.setScreen(new VTDownloadScreen(this, Constants.RESOURCE_PACK_SCREEN_SUBTITLE));
+            this.minecraft.setScreen(new VTDownloadScreen(this, Constants.RESOURCE_PACK_SCREEN_SUBTITLE));
         }).size(Util.VTD_BUTTON_WIDTH, Util.VTD_BUTTON_HEIGHT).build());
     }
 
@@ -64,25 +64,25 @@ public class PackScreenMixin extends Screen implements PackScreenAccess {
      * +INVOKEVIRTUAL L../ButtonWidget$Builder;width(I)L../ButtonWidget$Builder;
      * INVOKEVIRTUAL L../ButtonWidget$Builder;build()L../ButtonWidget;
      */
-    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/button/ButtonWidget$Builder;build()Lnet/minecraft/client/gui/widget/button/ButtonWidget;"),
-            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/layout/HeaderFooterLayoutWidget;addToFooter(Lnet/minecraft/client/gui/widget/Widget;)Lnet/minecraft/client/gui/widget/Widget;")))
-    private ButtonWidget shrinkVanillaButton(ButtonWidget.Builder builder) {
+    @Redirect(method = "init()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/Button$Builder;build()Lnet/minecraft/client/gui/components/Button;"),
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/layouts/HeaderAndFooterLayout;addToFooter(Lnet/minecraft/client/gui/layouts/LayoutElement;)Lnet/minecraft/client/gui/layouts/LayoutElement;")))
+    private Button shrinkVanillaButton(Button.Builder builder) {
         //noinspection ConstantValue
-        if (!this.vtdownloader$isResourcePackScreen() || (Class<?>) this.getClass() != PackScreen.class) {
+        if (!this.vtdownloader$isResourcePackScreen() || (Class<?>) this.getClass() != PackSelectionScreen.class) {
             return builder.build();
         }
 
-        return builder.width(ButtonWidget.SMALL_WIDTH).build();
+        return builder.width(Button.SMALL_WIDTH).build();
     }
 
     @Override
     public boolean vtdownloader$isResourcePackScreen() {
         // noinspection ConstantConditions
-        return this.file == this.client.getResourcePackDir();
+        return this.packDir == this.minecraft.getResourcePackDirectory();
     }
 
     @Override
     public void vtdownloader$applyChanges() {
-        this.organizer.apply();
+        this.model.commit();
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/mixin/ResourcePackOrganizerMixin.java
+++ b/src/main/java/me/bymartrixx/vtd/mixin/ResourcePackOrganizerMixin.java
@@ -1,22 +1,22 @@
 package me.bymartrixx.vtd.mixin;
 
 import me.bymartrixx.vtd.access.AbstractPackAccess;
-import net.minecraft.client.gui.screen.pack.ResourcePackOrganizer;
-import net.minecraft.resource.pack.PackProfile;
+import net.minecraft.client.gui.screens.packs.PackSelectionModel;
+import net.minecraft.server.packs.repository.Pack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-@Mixin(ResourcePackOrganizer.class)
+@Mixin(PackSelectionModel.class)
 public class ResourcePackOrganizerMixin {
-    @Mixin(targets = "net/minecraft/client/gui/screen/pack/ResourcePackOrganizer$AbstractPack")
+    @Mixin(targets = "net.minecraft.client.gui.screens.packs.PackSelectionModel$EntryBase")
     public static class AbstractPackMixin implements AbstractPackAccess {
         @Shadow @Final
-        private PackProfile profile;
+        private Pack pack;
 
         @Override
-        public PackProfile vtdownloader$getProfile() {
-            return this.profile;
+        public Pack vtdownloader$getProfile() {
+            return this.pack;
         }
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/mixin/TextureManagerMixin.java
+++ b/src/main/java/me/bymartrixx/vtd/mixin/TextureManagerMixin.java
@@ -1,9 +1,9 @@
 package me.bymartrixx.vtd.mixin;
 
 import me.bymartrixx.vtd.access.TextureManagerAccess;
-import net.minecraft.client.texture.AbstractTexture;
-import net.minecraft.client.texture.TextureManager;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -13,10 +13,10 @@ import java.util.Map;
 @Mixin(TextureManager.class)
 public class TextureManagerMixin implements TextureManagerAccess {
 	@Shadow @Final
-	private Map<Identifier, AbstractTexture> textures;
+	private Map<Identifier, AbstractTexture> byPath;
 
 	@Override
 	public boolean vtdownloader$hasTexture(Identifier id) {
-		return this.textures.containsKey(id);
+		return this.byPath.containsKey(id);
 	}
 }

--- a/src/main/java/me/bymartrixx/vtd/mixin/compat/RecursiveResourcesPackScreenMixin.java
+++ b/src/main/java/me/bymartrixx/vtd/mixin/compat/RecursiveResourcesPackScreenMixin.java
@@ -4,12 +4,12 @@ import me.bymartrixx.vtd.access.PackScreenAccess;
 import me.bymartrixx.vtd.gui.VTDownloadScreen;
 import me.bymartrixx.vtd.util.Constants;
 import me.bymartrixx.vtd.util.Util;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.pack.PackScreen;
-import net.minecraft.client.gui.widget.button.ButtonWidget;
-import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.resource.pack.PackManager;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.packs.PackSelectionScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.packs.repository.PackRepository;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,9 +23,9 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 @Mixin(targets = "nl.enjarai.recursiveresources.gui.FolderedResourcePackScreen")
-public abstract class RecursiveResourcesPackScreenMixin extends PackScreen implements PackScreenAccess {
+public abstract class RecursiveResourcesPackScreenMixin extends PackSelectionScreen implements PackScreenAccess {
     @Unique
-    private static final Text OPEN_FOLDER_TEXT = Text.translatable("pack.openFolder");
+    private static final Component OPEN_FOLDER_TEXT = Component.translatable("pack.openFolder");
     @Unique
     private static final int LIST_WIDTH = 200;
     @Unique
@@ -33,20 +33,20 @@ public abstract class RecursiveResourcesPackScreenMixin extends PackScreen imple
     @Unique
     private static final int BUTTON_MARGIN = 1;
     @Unique
-    private static final Text VTD_TEXT = Text.literal("VTDownloader");
+    private static final Component VTD_TEXT = Component.literal("VTDownloader");
     @Unique
     private static final int BUTTON_Y_OFFSET = 48;
 
-    public RecursiveResourcesPackScreenMixin(PackManager packManager, Consumer<PackManager> applier, Path file, Text title) {
+    public RecursiveResourcesPackScreenMixin(PackRepository packManager, Consumer<PackRepository> applier, Path file, Component title) {
         super(packManager, applier, file, title);
     }
 
     @Shadow(remap = false)
     @Final
-    protected MinecraftClient client;
+    protected Minecraft minecraft;
 
     @Shadow
-    protected abstract Optional<ClickableWidget> findButton(Text text);
+    protected abstract Optional<AbstractWidget> findButton(Component text);
 
     @Inject(at = @At(value = "TAIL"), method = "repositionElements")
     public void vt_downloader$addRecursiveResourcesButton(CallbackInfo ci) {
@@ -54,11 +54,11 @@ public abstract class RecursiveResourcesPackScreenMixin extends PackScreen imple
             button.setX(this.width / 2 + LIST_X_OFFSET + BUTTON_MARGIN);
             button.setWidth(LIST_WIDTH / 2 - BUTTON_MARGIN * 2);
         });
-        this.addDrawableSelectableElement(ButtonWidget.builder(VTD_TEXT, button -> {
+        this.addRenderableWidget(Button.builder(VTD_TEXT, button -> {
             this.vtdownloader$applyChanges();
-            this.client.setScreen(new VTDownloadScreen(this, Constants.RESOURCE_PACK_SCREEN_SUBTITLE));
+            this.minecraft.setScreen(new VTDownloadScreen(this, Constants.RESOURCE_PACK_SCREEN_SUBTITLE));
         })
-                .position((this.width + LIST_WIDTH) / 2 + LIST_X_OFFSET + BUTTON_MARGIN, this.height - BUTTON_Y_OFFSET)
+                .pos((this.width + LIST_WIDTH) / 2 + LIST_X_OFFSET + BUTTON_MARGIN, this.height - BUTTON_Y_OFFSET)
                 .size(LIST_WIDTH / 2 - BUTTON_MARGIN * 2, Util.VTD_BUTTON_HEIGHT)
                 .build());
     }

--- a/src/main/java/me/bymartrixx/vtd/util/Constants.java
+++ b/src/main/java/me/bymartrixx/vtd/util/Constants.java
@@ -1,17 +1,17 @@
 package me.bymartrixx.vtd.util;
 
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 
 public class Constants {
-    public static final Text ERROR_TEXT = Text.translatable("vtd.error").formatted(Formatting.BOLD);
-    public static final Text RESOURCE_PACK_SCREEN_SUBTITLE = Text.translatable("vtd.resourcePack.subtitle")
-            .formatted(Formatting.GRAY);
-    public static final Text RESOURCE_PACK_BUTTON_TEXT = Text.translatable("vtd.resourcePack.button");
-    public static final Text RESOURCE_PACK_RELOAD_TEXT = Text.translatable("vtd.resourcePack.reload");
+    public static final Component ERROR_TEXT = Component.translatable("vtd.error").withStyle(ChatFormatting.BOLD);
+    public static final Component RESOURCE_PACK_SCREEN_SUBTITLE = Component.translatable("vtd.resourcePack.subtitle")
+            .withStyle(ChatFormatting.GRAY);
+    public static final Component RESOURCE_PACK_BUTTON_TEXT = Component.translatable("vtd.resourcePack.button");
+    public static final Component RESOURCE_PACK_RELOAD_TEXT = Component.translatable("vtd.resourcePack.reload");
 
-    public static final Identifier PENCIL_TEXTURE = Identifier.of("vt_downloader", "textures/pencil.png");
+    public static final Identifier PENCIL_TEXTURE = Identifier.fromNamespaceAndPath("vt_downloader", "textures/pencil.png");
 
     public static final String VT_DESCRIPTION_MARKER = "vanillatweaks.net";
     public static final String SELECTED_PACKS_FILE = "Selected Packs.txt";

--- a/src/main/java/me/bymartrixx/vtd/util/RenderUtil.java
+++ b/src/main/java/me/bymartrixx/vtd/util/RenderUtil.java
@@ -1,7 +1,7 @@
 package me.bymartrixx.vtd.util;
 
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 import java.util.List;
 
@@ -9,25 +9,25 @@ public class RenderUtil {
     public static final int TEXT_MARGIN = 2;
     public static final int DEBUG_INFO_COLOR = 0xFFCCCCCC;
 
-    public static void drawOutline(GuiGraphics graphics, int x, int y, int width, int height, int size, int color) {
+    public static void drawOutline(GuiGraphicsExtractor graphics, int x, int y, int width, int height, int size, int color) {
         graphics.fill(x - size, y - size, x + width + size, y, color); // Top line
         graphics.fill(x - size, y + height, x + width + size, y + height + size, color); // Bottom line
         graphics.fill(x - size, y, x, y + height, color); // Left line
         graphics.fill(x + width, y, x + width + size, y + height, color); // Right line
     }
 
-    public static void renderDebugInfo(GuiGraphics graphics, TextRenderer textRenderer, int x, int endY, List<String> info) {
+    public static void renderDebugInfo(GuiGraphicsExtractor graphics, Font textRenderer, int x, int endY, List<String> info) {
         // Make text half its size
-        graphics.getMatrices().pushMatrix();
-        graphics.getMatrices().scale(0.5F, 0.5F);
+        graphics.pose().pushMatrix();
+        graphics.pose().scale(0.5F, 0.5F);
 
-        int lineHeight = textRenderer.fontHeight + TEXT_MARGIN;
+        int lineHeight = textRenderer.lineHeight + TEXT_MARGIN;
         int startY = endY * 2 - lineHeight * info.size();
         for (int i = 0; i < info.size(); i++) {
             String text = info.get(i);
-            graphics.drawString(textRenderer, text, x, startY + i * lineHeight, DEBUG_INFO_COLOR, false);
+            graphics.text(textRenderer, text, x, startY + i * lineHeight, DEBUG_INFO_COLOR, false);
         }
 
-        graphics.getMatrices().popMatrix();
+        graphics.pose().popMatrix();
     }
 }

--- a/src/main/java/me/bymartrixx/vtd/util/Util.java
+++ b/src/main/java/me/bymartrixx/vtd/util/Util.java
@@ -1,20 +1,20 @@
 package me.bymartrixx.vtd.util;
 
 import me.bymartrixx.vtd.VTDMod;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.MultilineText;
-import net.minecraft.client.font.TextHandler;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.screen.ConfirmLinkScreen;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.OrderedText;
-import net.minecraft.text.StringVisitable;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.util.ArgbHelper;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.StringSplitter;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.MultiLineLabel;
+import net.minecraft.client.gui.screens.ConfirmLinkScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.util.ARGB;
+import net.minecraft.util.FormattedCharSequence;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,7 +45,7 @@ public class Util {
                     int blue = Integer.parseInt(components.get(2));
                     float alpha = Float.parseFloat(components.get(3));
 
-                    return ArgbHelper.pack((int) (alpha * 255), red, green, blue);
+                    return ARGB.color((int) (alpha * 255), red, green, blue);
                 }
             }
         }
@@ -60,53 +60,53 @@ public class Util {
                 .replaceAll("<br>", "\n"); // Replace <br> after normalizing to keep new lines
     }
 
-    public static Text urlText(String url) {
-        MutableText t = Text.literal(url)
-                .formatted(Formatting.UNDERLINE, Formatting.ITALIC, Formatting.BLUE);
+    public static Component urlText(String url) {
+        MutableComponent t = Component.literal(url)
+                .withStyle(ChatFormatting.UNDERLINE, ChatFormatting.ITALIC, ChatFormatting.BLUE);
         try {
-            URI uri = net.minecraft.util.Util.createUri(url);
-            t.styled(s -> s.withClickEvent(new ClickEvent.OpenUrl(uri)));
+            URI uri = net.minecraft.util.Util.parseAndValidateUntrustedUri(url);
+            t.withStyle(s -> s.withClickEvent(new ClickEvent.OpenUrl(uri)));
         } catch (URISyntaxException ignored) {
         }
 
         return t;
     }
 
-    public static void openUri(MinecraftClient client, @Nullable Screen screen, URI uri) {
-        if (client.options.getChatLinksPrompt().get()) {
+    public static void openUri(Minecraft client, @Nullable Screen screen, URI uri) {
+        if (client.options.chatLinksPrompt().get()) {
             client.setScreen(new ConfirmLinkScreen(open -> {
                 if (open) {
-                    net.minecraft.util.Util.getOperatingSystem().open(uri);
+                    net.minecraft.util.Util.getPlatform().openUri(uri);
                 }
 
                 client.setScreen(screen);
             }, uri.toString(), false));
         } else {
-            net.minecraft.util.Util.getOperatingSystem().open(uri);
+            net.minecraft.util.Util.getPlatform().openUri(uri);
         }
     }
 
-    public static List<OrderedText> getMultilineTextLines(TextRenderer textRenderer, Text text, int maxLines, int width) {
-        return textRenderer.wrapLines(text, width).stream()
+    public static List<FormattedCharSequence> getMultilineTextLines(Font textRenderer, Component text, int maxLines, int width) {
+        return textRenderer.split(text, width).stream()
                 .limit(maxLines)
                 .toList();
     }
 
-    public static MultilineText createMultilineText(TextRenderer textRenderer, Text text, int maxLines, int width) {
-        return MultilineText.create(textRenderer, width, maxLines, text);
+    public static MultiLineLabel createMultilineText(Font textRenderer, Component text, int maxLines, int width) {
+        return MultiLineLabel.create(textRenderer, width, maxLines, text);
     }
 
-    public static MultilineText createMultilineText(TextRenderer textRenderer, List<Text> lines, int maxLines) {
+    public static MultiLineLabel createMultilineText(Font textRenderer, List<Component> lines, int maxLines) {
         if (lines.size() > maxLines) {
             lines = lines.subList(0, maxLines);
         }
 
-        return MultilineText.create(textRenderer, lines.toArray(new Text[0]));
+        return MultiLineLabel.create(textRenderer, lines.toArray(new Component[0]));
     }
 
-    public static List<Text> wrapText(TextRenderer textRenderer, String text, int maxWidth) {
-        TextHandler textHandler = textRenderer.getTextHandler();
-        List<StringVisitable> visitableLines = textHandler.wrapLines(text, maxWidth, Style.EMPTY);
-        return visitableLines.stream().map(StringVisitable::getString).map(Text::of).toList();
+    public static List<Component> wrapText(Font textRenderer, String text, int maxWidth) {
+        StringSplitter textHandler = textRenderer.getSplitter();
+        List<FormattedText> visitableLines = textHandler.splitLines(text, maxWidth, Style.EMPTY);
+        return visitableLines.stream().map(FormattedText::getString).map(Component::nullToEmpty).toList();
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,22 @@
     "authors": [
         "IotaBread"
     ],
+    "contributors": [
+        "arthomnix",
+        "NiTiSon",
+        "BifidoKephir",
+        "osfanbuff63",
+        "Calvineries",
+        "EvanHsieh0415",
+        "Gazmanovich",
+        "StarmanMine142",
+        "Aglomation",
+        "Kikaayy",
+        "NuruddinPlays",
+        "CoolAid48"
+    ],
     "contact": {
+        "homepage": "https://modrinth.com/mod/vtdownloader",
         "sources": "https://github.com/IotaBread/VTDownloader",
         "issues": "https://github.com/IotaBread/VTDownloader/issues"
     },
@@ -28,7 +43,9 @@
     ],
 
     "depends": {
-        "minecraft": "~1.21"
+        "fabricloader": ">=0.19.3",
+        "fabric-api": "*",
+        "minecraft": "~26.1"
     },
 
     "custom": {

--- a/src/main/resources/vt_downloader.mixins.json
+++ b/src/main/resources/vt_downloader.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "me.bymartrixx.vtd.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [],
   "client": [
     "PackEntryListWidgetMixin",

--- a/src/main/resources/vt_downloader_compat.mixins.json
+++ b/src/main/resources/vt_downloader_compat.mixins.json
@@ -2,7 +2,7 @@
   "required": false,
   "package": "me.bymartrixx.vtd.mixin.compat",
   "plugin": "me.bymartrixx.vtd.mixin.compat.CompatMixinConfigPlugin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [],
   "client": [
     "RecursiveResourcesPackScreenMixin"


### PR DESCRIPTION
- Version bump to 2.4.2+26.1
- Updated Gradle build for 26.1/Java 25 compatibility
- Added past and current contributors to metadata, added link to Modrinth page, and updated version dependencies
- Updated VTDownloader logic and resource pack screen integration for Minecraft and Vanilla Tweaks 26.1
- Updated the VTDownloader button and edit-pencil behavior on the resource pack screen
- Ported screens, widgets, popups, tooltips, and text rendering to the new GUI APIs
- Updated resource pack reading and saving for the new pack selection APIs
- Removed outdated Quilt mapping and CurseGradle build configuration